### PR TITLE
[Spike] Introduce deployment annotation

### DIFF
--- a/deploy/backend_deploy.yaml
+++ b/deploy/backend_deploy.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: backend
+  name: backend-deployment
   namespace: default
   annotations:
     lingo.substratus.ai/models: backend

--- a/deploy/backend_service.yaml
+++ b/deploy/backend_service.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: backend
+  name: backend-service
   namespace: default
+  annotations:
+    lingo.substratus.ai/deployment: backend-deployment
 spec:
   selector:
     app: backend

--- a/deploy/lingo_service.yaml
+++ b/deploy/lingo_service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: lingo
   namespace: default
+  annotations:
+    lingo.substratus.ai/deployment: lingo # make visible for autoscaler
 spec:
   selector:
     app: lingo

--- a/pkg/endpoints/manager.go
+++ b/pkg/endpoints/manager.go
@@ -6,17 +6,22 @@ import (
 	"log"
 	"sync"
 
+	corev1 "k8s.io/api/core/v1"
+
 	disv1 "k8s.io/api/discovery/v1"
 
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func NewManager(mgr ctrl.Manager) (*Manager, error) {
-	r := &Manager{}
-	r.Client = mgr.GetClient()
-	r.endpoints = map[string]*endpointGroup{}
-	r.ExcludePods = map[string]struct{}{}
+	r := &Manager{
+		Client:              mgr.GetClient(),
+		endpoints:           make(map[string]*endpointGroup),
+		serviceToDeployment: make(map[string]string),
+		ExcludePods:         make(map[string]struct{}),
+	}
 	if err := r.SetupWithManager(mgr); err != nil {
 		return nil, err
 	}
@@ -29,18 +34,43 @@ type Manager struct {
 	EndpointSizeCallback func(deploymentName string, size int)
 
 	endpointsMtx sync.Mutex
-	endpoints    map[string]*endpointGroup
+	endpoints    map[string]*endpointGroup // deployment to endpoints
+
+	serviceToDeploymentMtx sync.RWMutex
+	serviceToDeployment    map[string]string
 
 	ExcludePods map[string]struct{}
 }
 
 func (r *Manager) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	err := ctrl.NewControllerManagedBy(mgr).
 		For(&disv1.EndpointSlice{}).
-		Complete(r)
+		Complete(ReconcilerFn(r.ReconcileEndpointSlices))
+	if err != nil {
+		return err
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Service{}).
+		Complete(ReconcilerFn(r.ReconcileServices))
 }
 
-func (r *Manager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *Manager) ReconcileServices(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var svc corev1.Service
+	if err := r.Get(ctx, req.NamespacedName, &svc); err != nil {
+		// todo: handle service undeployment
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	deploymentName := getDeploymentFromAnnotation(svc.Annotations)
+	if deploymentName == "" {
+		return ctrl.Result{}, nil
+	}
+	r.serviceToDeploymentMtx.Lock()
+	r.serviceToDeployment[req.Name] = deploymentName // todo: should be namespaced names instead
+	r.serviceToDeploymentMtx.Unlock()
+	return ctrl.Result{}, nil
+}
+
+func (r *Manager) ReconcileEndpointSlices(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var slice disv1.EndpointSlice
 	if err := r.Get(ctx, req.NamespacedName, &slice); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -53,11 +83,28 @@ func (r *Manager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result,
 		return ctrl.Result{}, nil
 	}
 
+	r.serviceToDeploymentMtx.RLock()
+	deploymentName, ok := r.serviceToDeployment[serviceName]
+	r.serviceToDeploymentMtx.RUnlock()
+	if !ok {
+		// maybe triggered before service, let's reconcile
+		if _, err := r.ReconcileServices(ctx, ctrl.Request{k8stypes.NamespacedName{Namespace: req.Namespace, Name: serviceName}}); err != nil {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		r.serviceToDeploymentMtx.RLock()
+		deploymentName, ok = r.serviceToDeployment[serviceName]
+		r.serviceToDeploymentMtx.RUnlock()
+		if !ok {
+			// still not there, then svc is not annotated
+			log.Printf("no deployment for service: %q", req.Name)
+			return ctrl.Result{}, nil
+		}
+	}
+
 	var sliceList disv1.EndpointSliceList
 	if err := r.List(ctx, &sliceList, client.MatchingLabels{serviceNameLabel: serviceName}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("listing endpointslices: %w", err)
 	}
-
 	ips := map[string]struct{}{}
 	for _, sliceItem := range sliceList.Items {
 		for _, endpointItem := range sliceItem.Endpoints {
@@ -86,25 +133,25 @@ func (r *Manager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result,
 		}
 	}
 
-	priorLen := r.getEndpoints(serviceName).lenIPs()
-	r.getEndpoints(serviceName).setIPs(ips, ports)
+	priorLen := r.getEndpoints(deploymentName).lenIPs()
+	r.getEndpoints(deploymentName).setIPs(ips, ports)
 
 	if priorLen != len(ips) {
 		// TODO: Currently Service name needs to match Deployment name, however
 		// this shouldn't be the case. We should be able to reference deployment
 		// replicas by something else.
-		r.EndpointSizeCallback(serviceName, len(ips))
+		r.EndpointSizeCallback(deploymentName, len(ips))
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func (r *Manager) getEndpoints(service string) *endpointGroup {
+func (r *Manager) getEndpoints(deployment string) *endpointGroup {
 	r.endpointsMtx.Lock()
-	e, ok := r.endpoints[service]
+	e, ok := r.endpoints[deployment]
 	if !ok {
 		e = newEndpointGroup()
-		r.endpoints[service] = e
+		r.endpoints[deployment] = e
 	}
 	r.endpointsMtx.Unlock()
 	return e
@@ -114,11 +161,36 @@ func (r *Manager) getEndpoints(service string) *endpointGroup {
 // becomes available or the context times out.
 //
 // It returns a string in the format "host:port" or error on timeout
-func (r *Manager) AwaitHostAddress(ctx context.Context, service, portName string) (string, error) {
-	return r.getEndpoints(service).getBestHost(ctx, portName)
+func (r *Manager) AwaitHostAddress(ctx context.Context, deployment, portName string) (string, error) {
+	return r.getEndpoints(deployment).getBestHost(ctx, portName)
 }
 
 // GetAllHosts retrieves the list of all hosts for a given service and port.
 func (r *Manager) GetAllHosts(service, portName string) []string {
-	return r.getEndpoints(service).getAllHosts(portName)
+	r.serviceToDeploymentMtx.RLock()
+	defer r.serviceToDeploymentMtx.RUnlock()
+	depName, ok := r.serviceToDeployment[service]
+	if !ok {
+		return nil
+	}
+	return r.getEndpoints(depName).getAllHosts(portName)
+}
+
+type ReconcilerFn func(ctx context.Context, req ctrl.Request) (ctrl.Result, error)
+
+func (r ReconcilerFn) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return r(ctx, req)
+}
+
+const lingoDeploymentAnnotation = "lingo.substratus.ai/deployment"
+
+func getDeploymentFromAnnotation(ann map[string]string) string {
+	if len(ann) == 0 {
+		return ""
+	}
+	modelCSV, ok := ann[lingoDeploymentAnnotation]
+	if !ok {
+		return ""
+	}
+	return modelCSV
 }


### PR DESCRIPTION
🚧  Spike to demo an alternative solution for #59 

This PR introduces a new `lingo.substratus.ai/deployment` annotation for lingo managed services so that names are not tightly coupled