### PR TITLE
Publish KubeAI Arm container image

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
         if: github.event_name == 'push'
         uses: docker/login-action@v3

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Log in to the Container registry
         if: github.event_name == 'push'
         uses: docker/login-action@v3
@@ -49,6 +51,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The simple AI platform that runs on Kubernetes.
 > \- Some Google Engineer
 
 ✅️  Drop-in replacement for OpenAI with API compatibility  
-🚀  Serve OSS LLMs on CPUs or GPUs  
+🚀  Serve LLMs on CPUs (Arm & X86) or GPUs  
 ⚖️  Scale from zero, autoscale based on load  
 🛠️  Zero dependencies (no Istio, Knative, etc.)   
 🤖  Operates OSS model servers (vLLM and Ollama)  

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The simple AI platform that runs on Kubernetes.
 > \- Some Google Engineer
 
 ✅️  Drop-in replacement for OpenAI with API compatibility  
-🚀  Serve LLMs on CPUs (Arm & X86) or GPUs  
+🚀  Serve OSS LLMs on CPUs or GPUs  
 ⚖️  Scale from zero, autoscale based on load  
 🛠️  Zero dependencies (no Istio, Knative, etc.)   
 🤖  Operates OSS model servers (vLLM and Ollama)  


### PR DESCRIPTION
fixes #134

Note the vLLM CPU image does not support Arm, but this commit publishes kubeai compatible arm image. The upstream vLLM GPU image does seem to support Arm out of the box. The Ollama image also supports Arm already. 