### PR TITLE
Map resource profiles to images & add resource profile doc

### DIFF
--- a/api/v1/model_types.go
+++ b/api/v1/model_types.go
@@ -38,6 +38,10 @@ type ModelSpec struct {
 	// ResourceProfile maps to specific pre-configured resources.
 	ResourceProfile string `json:"resourceProfile,omitempty"`
 
+	// Image to be used for the server process.
+	// Will be set from the ResourceProfile if provided.
+	Image string `json:"image,omitempty"`
+
 	// Resources to be allocated to the server process.
 	// Will be set from the ResourceProfile if provided.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/charts/kubeai/Chart.yaml
+++ b/charts/kubeai/Chart.yaml
@@ -7,13 +7,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.4.2"
+appVersion: "v0.4.3"
 
 dependencies:
   # Open Web UI is an open source ChatGPT-like user interface.

--- a/charts/kubeai/Chart.yaml
+++ b/charts/kubeai/Chart.yaml
@@ -13,7 +13,7 @@ version: 0.2.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.4.3"
+appVersion: "v0.4.2"
 
 dependencies:
   # Open Web UI is an open source ChatGPT-like user interface.

--- a/charts/kubeai/charts/crds/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/charts/crds/crds/kubeai.org_models.yaml
@@ -61,6 +61,11 @@ spec:
                   - TextEmbedding
                   type: string
                 type: array
+              image:
+                description: |-
+                  Image to be used for the server process.
+                  Will be set from the ResourceProfile if provided.
+                type: string
               maxReplicas:
                 format: int32
                 type: integer

--- a/charts/kubeai/charts/models/values.yaml
+++ b/charts/kubeai/charts/models/values.yaml
@@ -9,6 +9,7 @@ catalog:
     features: ["TextEmbedding"]
     owner: intfloat
     url: "hf://intfloat/e5-mistral-7b-instruct"
+    server: VLLM
     resourceProfile: CPU:1
     args:
     - --gpu-memory-utilization=0.9
@@ -18,7 +19,7 @@ catalog:
     features: ["TextGeneration"]
     owner: google
     url: "ollama://gemma2:2b"
-    engine: OLlama
+    server: OLlama
     resourceProfile: CPU:2
   # Llama #
   llama-3.1-8b-instruct-cpu:
@@ -26,7 +27,7 @@ catalog:
     features: ["TextGeneration"]
     owner: "meta-llama"
     url: "hf://meta-llama/Meta-Llama-3.1-8B-Instruct"
-    engine: VLLM
+    server: VLLM
     resourceProfile: CPU:6
     env:
       VLLM_CPU_KVCACHE_SPACE: "4"
@@ -38,8 +39,8 @@ catalog:
     features: ["TextGeneration"]
     owner: "neuralmagic"
     url: "hf://neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8"
-    engine: VLLM
-    resourceProfile: L4:1
+    server: VLLM
+    resourceProfile: NVIDIA_GPU_L4:1
     args:
     - --max-model-len=16384
     - --max-num-batched-token=16384
@@ -50,7 +51,7 @@ catalog:
     features: ["TextEmbedding"]
     owner: nomic
     url: "ollama://nomic-embed-text"
-    engine: OLlama
+    server: OLlama
     resourceProfile: CPU:1
   # Opt #
   opt-125m-cpu:
@@ -58,21 +59,21 @@ catalog:
     features: ["TextGeneration"]
     owner: facebook
     url: "hf://facebook/opt-125m"
-    engine: VLLM
+    server: VLLM
     resourceProfile: CPU:1
   opt-125m-l4:
     enabled: false
     features: ["TextGeneration"]
     owner: facebook
     url: "hf://facebook/opt-125m"
-    engine: VLLM
-    resourceProfile: L4:1
+    server: VLLM
+    resourceProfile: NVIDIA_GPU_L4:1
   # Qwen #
   qwen2-500m-cpu:
     enabled: false
     features: ["TextGeneration"]
     owner: alibaba
     url: "ollama://qwen2:0.5b"
-    engine: OLlama
+    server: OLlama
     resourceProfile: CPU:1
 

--- a/charts/kubeai/charts/models/values.yaml
+++ b/charts/kubeai/charts/models/values.yaml
@@ -9,7 +9,7 @@ catalog:
     features: ["TextEmbedding"]
     owner: intfloat
     url: "hf://intfloat/e5-mistral-7b-instruct"
-    server: VLLM
+    engine: VLLM
     resourceProfile: CPU:1
     args:
     - --gpu-memory-utilization=0.9
@@ -19,7 +19,7 @@ catalog:
     features: ["TextGeneration"]
     owner: google
     url: "ollama://gemma2:2b"
-    server: OLlama
+    engine: OLlama
     resourceProfile: CPU:2
   # Llama #
   llama-3.1-8b-instruct-cpu:
@@ -27,7 +27,7 @@ catalog:
     features: ["TextGeneration"]
     owner: "meta-llama"
     url: "hf://meta-llama/Meta-Llama-3.1-8B-Instruct"
-    server: VLLM
+    engine: VLLM
     resourceProfile: CPU:6
     env:
       VLLM_CPU_KVCACHE_SPACE: "4"
@@ -39,7 +39,7 @@ catalog:
     features: ["TextGeneration"]
     owner: "neuralmagic"
     url: "hf://neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8"
-    server: VLLM
+    engine: VLLM
     resourceProfile: NVIDIA_GPU_L4:1
     args:
     - --max-model-len=16384
@@ -51,7 +51,7 @@ catalog:
     features: ["TextEmbedding"]
     owner: nomic
     url: "ollama://nomic-embed-text"
-    server: OLlama
+    engine: OLlama
     resourceProfile: CPU:1
   # Opt #
   opt-125m-cpu:
@@ -59,14 +59,14 @@ catalog:
     features: ["TextGeneration"]
     owner: facebook
     url: "hf://facebook/opt-125m"
-    server: VLLM
+    engine: VLLM
     resourceProfile: CPU:1
   opt-125m-l4:
     enabled: false
     features: ["TextGeneration"]
     owner: facebook
     url: "hf://facebook/opt-125m"
-    server: VLLM
+    engine: VLLM
     resourceProfile: NVIDIA_GPU_L4:1
   # Qwen #
   qwen2-500m-cpu:
@@ -74,6 +74,6 @@ catalog:
     features: ["TextGeneration"]
     owner: alibaba
     url: "ollama://qwen2:0.5b"
-    server: OLlama
+    engine: OLlama
     resourceProfile: CPU:1
 

--- a/charts/kubeai/charts/models/values.yaml
+++ b/charts/kubeai/charts/models/values.yaml
@@ -10,7 +10,7 @@ catalog:
     owner: intfloat
     url: "hf://intfloat/e5-mistral-7b-instruct"
     engine: VLLM
-    resourceProfile: CPU:1
+    resourceProfile: cpu:1
     args:
     - --gpu-memory-utilization=0.9
   # Gemma #
@@ -20,7 +20,7 @@ catalog:
     owner: google
     url: "ollama://gemma2:2b"
     engine: OLlama
-    resourceProfile: CPU:2
+    resourceProfile: cpu:2
   # Llama #
   llama-3.1-8b-instruct-cpu:
     enabled: false
@@ -28,7 +28,7 @@ catalog:
     owner: "meta-llama"
     url: "hf://meta-llama/Meta-Llama-3.1-8B-Instruct"
     engine: VLLM
-    resourceProfile: CPU:6
+    resourceProfile: cpu:6
     env:
       VLLM_CPU_KVCACHE_SPACE: "4"
     args:
@@ -40,7 +40,7 @@ catalog:
     owner: "neuralmagic"
     url: "hf://neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8"
     engine: VLLM
-    resourceProfile: NVIDIA_GPU_L4:1
+    resourceProfile: nvidia-gpu-l4:1
     args:
     - --max-model-len=16384
     - --max-num-batched-token=16384
@@ -52,7 +52,7 @@ catalog:
     owner: nomic
     url: "ollama://nomic-embed-text"
     engine: OLlama
-    resourceProfile: CPU:1
+    resourceProfile: cpu:1
   # Opt #
   opt-125m-cpu:
     enabled: false
@@ -60,14 +60,14 @@ catalog:
     owner: facebook
     url: "hf://facebook/opt-125m"
     engine: VLLM
-    resourceProfile: CPU:1
+    resourceProfile: cpu:1
   opt-125m-l4:
     enabled: false
     features: ["TextGeneration"]
     owner: facebook
     url: "hf://facebook/opt-125m"
     engine: VLLM
-    resourceProfile: NVIDIA_GPU_L4:1
+    resourceProfile: nvidia-gpu-l4:1
   # Qwen #
   qwen2-500m-cpu:
     enabled: false
@@ -75,5 +75,5 @@ catalog:
     owner: alibaba
     url: "ollama://qwen2:0.5b"
     engine: OLlama
-    resourceProfile: CPU:1
+    resourceProfile: cpu:1
 

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -14,21 +14,24 @@ secrets:
 modelServers:
   VLLM:
     images:
-      # The key is the resource profile name (with "*" matching), and the value is the image to use.
-      "*": "vllm/vllm-openai:v0.5.5"
-      "CPU*": "substratusai/vllm-openai-cpu:v0.5.5"
-      "NVIDIA_GPU*": "vllm/vllm-openai:v0.5.5"
-      "GOOGLE_TPU*": "substratusai/vllm-openai-tpu:v0.5.5"
+      # The key is the image name (referenced from resourceProfiles) and the value is the image.
+      # "default" is used when no imageName is specified or if a specific image is not found.
+      default: "vllm/vllm-openai:v0.5.5"
+      cpu: "substratusai/vllm-openai-cpu:v0.5.5"
+      nvidia-gpu: "vllm/vllm-openai:v0.5.5"
+      google-tpu: "substratusai/vllm-openai-tpu:v0.5.5"
   OLlama:
     images:
-      "*": "ollama/ollama:latest"
+      default: "ollama/ollama:latest"
 
 resourceProfiles:
   CPU:
+    imageName: "cpu"
     requests:
       cpu: 1
       memory: "2Gi"
   NVIDIA_GPU_L4:
+    imageName: "nvidia-gpu"
     limits:
       nvidia.com/gpu: "1"
     requests:
@@ -40,6 +43,7 @@ resourceProfiles:
   # NVIDIA_GPU_A100:
     # ...
   GOOGLE_TPU_V5E:
+    imageName: "google-tpu"
     requests:
       google.com/tpu: 4
     limits:

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -12,24 +12,40 @@ secrets:
     name: ""
 
 modelServers:
-  vLLM:
-    gpuImage: "vllm/vllm-openai:v0.5.5"
-    cpuImage: "substratusai/vllm:v0.5.5-cpu"
-  ollama:
-    image: "ollama/ollama:latest"
+  VLLM:
+    images:
+      # The key is the resource profile name (with "*" matching), and the value is the image to use.
+      "*": "vllm/vllm-openai:v0.5.5"
+      "CPU*": "substratusai/vllm-openai-cpu:v0.5.5"
+      "NVIDIA_GPU*": "vllm/vllm-openai:v0.5.5"
+      "GOOGLE_TPU*": "substratusai/vllm-openai-tpu:v0.5.5"
+  OLlama:
+    images:
+      "*": "ollama/ollama:latest"
 
 resourceProfiles:
   CPU:
     requests:
       cpu: 1
       memory: "2Gi"
-  L4:
+  NVIDIA_GPU_L4:
     limits:
       nvidia.com/gpu: "1"
     requests:
       nvidia.com/gpu: "1"
       cpu: "6"
       memory: "24Gi"
+  # NVIDIA_GPU_V100:
+    # ...
+  # NVIDIA_GPU_A100:
+    # ...
+  GOOGLE_TPU_V5E:
+    requests:
+      google.com/tpu: 4
+    limits:
+      google.com/tpu: 4
+    nodeSelector:
+      cloud.google.com/gke-accelerator-type: tpu-v5-lite-podslice
 
 messaging:
   errorMaxBackoff: 30s

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -26,12 +26,12 @@ modelServers:
       default: "ollama/ollama:latest"
 
 resourceProfiles:
-  CPU:
+  cpu:
     imageName: "cpu"
     requests:
       cpu: 1
       memory: "2Gi"
-  NVIDIA_GPU_L4:
+  nvidia-gpu-l4:
     imageName: "nvidia-gpu"
     limits:
       nvidia.com/gpu: "1"
@@ -39,18 +39,16 @@ resourceProfiles:
       nvidia.com/gpu: "1"
       cpu: "6"
       memory: "24Gi"
-  # NVIDIA_GPU_V100:
-    # ...
-  # NVIDIA_GPU_A100:
-    # ...
-  GOOGLE_TPU_V5E:
-    imageName: "google-tpu"
-    requests:
-      google.com/tpu: 4
-    limits:
-      google.com/tpu: 4
-    nodeSelector:
-      cloud.google.com/gke-accelerator-type: tpu-v5-lite-podslice
+  #nvidia-gpu-v100:
+  #nvidia-gpu-a100:
+  #google-tpu-v5e:
+  #  imageName: "google-tpu"
+  #  requests:
+  #    google.com/tpu: 4
+  #  limits:
+  #    google.com/tpu: 4
+  #  nodeSelector:
+  #    cloud.google.com/gke-accelerator-type: tpu-v5-lite-podslice
 
 messaging:
   errorMaxBackoff: 30s

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -39,16 +39,16 @@ resourceProfiles:
       nvidia.com/gpu: "1"
       cpu: "6"
       memory: "24Gi"
-  #nvidia-gpu-v100:
-  #nvidia-gpu-a100:
-  #google-tpu-v5e:
-  #  imageName: "google-tpu"
-  #  requests:
-  #    google.com/tpu: 4
-  #  limits:
-  #    google.com/tpu: 4
-  #  nodeSelector:
-  #    cloud.google.com/gke-accelerator-type: tpu-v5-lite-podslice
+  # nvidia-gpu-v100:
+  # nvidia-gpu-a100:
+  # google-tpu-v5e:
+  #   imageName: "google-tpu"
+  #   requests:
+  #     google.com/tpu: 4
+  #   limits:
+  #     google.com/tpu: 4
+  #   nodeSelector:
+  #     cloud.google.com/gke-accelerator-type: tpu-v5-lite-podslice
 
 messaging:
   errorMaxBackoff: 30s

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -15,6 +15,7 @@ modelServers:
   VLLM:
     images:
       # The key is the image name (referenced from resourceProfiles) and the value is the image.
+      # The "default" image should always be specified.
       # "default" is used when no imageName is specified or if a specific image is not found.
       default: "vllm/vllm-openai:v0.5.5"
       cpu: "substratusai/vllm-openai-cpu:v0.5.5"

--- a/docs/concepts/resource-profiles.md
+++ b/docs/concepts/resource-profiles.md
@@ -1,0 +1,51 @@
+# Resource Profiles
+
+A resource profile maps a type of compute resource (i.e. NVIDIA L4 GPU) to a collection of Kubernetes settings that are set on inference server Pods. These profiles are defined in the KubeAI `config.yaml` file (via a ConfigMap). Each model specifies the resource profile that it requires.
+
+Kubernetes Model resources specify the resource profile and the count of that resource that they require:
+
+```yaml
+# model.yaml
+apiVersion: kubeai.org/v1
+kind: Model
+metadata:
+  name: llama-3.1-8b-instruct-fp8-l4
+spec:
+  engine: VLLM
+  resourceProfile: NVIDIA_GPU_L4:1 # Specified at <profile>:<count>
+  # ...
+```
+A given profile might need to contain slightly different settings based on the cluster/cloud that KubeAI is deployed on.
+
+Example: A resource profile named `NVIDIA_GPU_L4` might contain the following settings on a GKE Kubernetes cluster:
+
+```yaml
+# KubeAI config.yaml
+resourceProfiles:
+  NVIDIA_GPU_L4:
+    limits:
+      # Typical across most Kubernetes clusters:
+      nvidia.com/gpu: "1"
+    requests:
+      nvidia.com/gpu: "1"
+    nodeSelector:
+      # Specific to GKE:
+      cloud.google.com/gke-accelerator: "nvidia-l4"
+      cloud.google.com/gke-spot: "true"
+    imageName: "nvidia-gpu"
+```
+
+In addition to node selectors and resource requirements, a resource profile may optionally specify an image name. This name maps to the container image that will be selected when serving a model on that resource:
+
+```yaml
+# KubeAI config.yaml
+modelServers:
+  VLLM:
+    images:
+      default: "vllm/vllm-openai:v0.5.5"
+      nvidia-gpu: "vllm/vllm-openai:v0.5.5" # <--
+      cpu: "vllm/vllm-openai-cpu:v0.5.5"
+  OLlama:
+    images:
+      # ...
+```

--- a/docs/concepts/resource-profiles.md
+++ b/docs/concepts/resource-profiles.md
@@ -12,7 +12,7 @@ metadata:
   name: llama-3.1-8b-instruct-fp8-l4
 spec:
   engine: VLLM
-  resourceProfile: NVIDIA_GPU_L4:1 # Specified at <profile>:<count>
+  resourceProfile: nvidia-gpu-l4:1 # Specified at <profile>:<count>
   # ...
 ```
 A given profile might need to contain slightly different settings based on the cluster/cloud that KubeAI is deployed on.
@@ -22,7 +22,7 @@ Example: A resource profile named `NVIDIA_GPU_L4` might contain the following se
 ```yaml
 # KubeAI config.yaml
 resourceProfiles:
-  NVIDIA_GPU_L4:
+  nvidia-gpu-l4:
     limits:
       # Typical across most Kubernetes clusters:
       nvidia.com/gpu: "1"

--- a/docs/installation/gke.md
+++ b/docs/installation/gke.md
@@ -45,7 +45,7 @@ models:
       enabled: true
 
 resourceProfiles:
-  L4:
+  nvidia-gpu-l4:
     nodeSelector:
       cloud.google.com/gke-accelerator: "nvidia-l4"
       cloud.google.com/gke-spot: "true"

--- a/docs/model-management.md
+++ b/docs/model-management.md
@@ -13,14 +13,14 @@ spec:
   features: ["TextGeneration"]
   owner: neuralmagic
   url: hf://neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8
-  engine: VLLM
+  server: VLLM
   args:
     - --max-model-len=16384
     - --max-num-batched-token=16384
     - --gpu-memory-utilization=0.9
   minReplicas: 0
   maxReplicas: 3
-  resourceProfile: L4:1
+  resourceProfile: NVIDIA_GPU_L4:1
 ```
 
 ### Listing Models

--- a/docs/model-management.md
+++ b/docs/model-management.md
@@ -20,7 +20,7 @@ spec:
     - --gpu-memory-utilization=0.9
   minReplicas: 0
   maxReplicas: 3
-  resourceProfile: NVIDIA_GPU_L4:1
+  resourceProfile: nvidia-gpu-l4:1
 ```
 
 ### Listing Models

--- a/docs/model-management.md
+++ b/docs/model-management.md
@@ -13,7 +13,7 @@ spec:
   features: ["TextGeneration"]
   owner: neuralmagic
   url: hf://neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8
-  server: VLLM
+  engine: VLLM
   args:
     - --max-model-len=16384
     - --max-num-batched-token=16384

--- a/hack/dev-config.yaml
+++ b/hack/dev-config.yaml
@@ -2,16 +2,19 @@ secretNames:
   huggingface: huggingface
 modelServers:
   vLLM:
-    gpuImage: "vllm/vllm-openai:latest"
-    cpuImage: "us-central1-docker.pkg.dev/substratus-dev/default/vllm-cpu:v0.5.4-118-gfc93e561"
+    images:
+      default: "vllm/vllm-openai:latest"
+      cpu: "us-central1-docker.pkg.dev/substratus-dev/default/vllm-cpu:v0.5.4-118-gfc93e561"
   ollama:
-    image: "ollama/ollama:latest"
+    images:
+      default: "ollama/ollama:latest"
+      cpu: "ollama/ollama:0.3.8"
 messaging:
   errorMaxBackoff: 30s
-  streams:
-  - requestsURL: gcppubsub://projects/substratus-dev/subscriptions/test-kubeai-requests-sub
-    responsesURL: gcppubsub://projects/substratus-dev/topics/test-kubeai-responses
-    maxHandlers: 1
+  streams: []
+  #- requestsURL: gcppubsub://projects/substratus-dev/subscriptions/test-kubeai-requests-sub
+  #  responsesURL: gcppubsub://projects/substratus-dev/topics/test-kubeai-responses
+  #  maxHandlers: 1
 resourceProfiles:
   CPU:
     requests:

--- a/hack/dev-config.yaml
+++ b/hack/dev-config.yaml
@@ -16,11 +16,11 @@ messaging:
   #  responsesURL: gcppubsub://projects/substratus-dev/topics/test-kubeai-responses
   #  maxHandlers: 1
 resourceProfiles:
-  CPU:
+  cpu:
     requests:
       cpu: 1
       memory: 2Gi
-  L4:
+  nvidia-gpu-l4:
     limits:
       nvidia.com/gpu: "1"
     requests:

--- a/hack/dev-gke-helm-values.yaml
+++ b/hack/dev-gke-helm-values.yaml
@@ -1,0 +1,10 @@
+models:
+  catalog:
+    llama-3.1-8b-instruct-fp8-l4:
+      enabled: true
+
+resourceProfiles:
+  NVIDIA_GPU_L4:
+    nodeSelector:
+      cloud.google.com/gke-accelerator: "nvidia-l4"
+      cloud.google.com/gke-spot: "true"

--- a/hack/dev-gke-helm-values.yaml
+++ b/hack/dev-gke-helm-values.yaml
@@ -4,7 +4,7 @@ models:
       enabled: true
 
 resourceProfiles:
-  NVIDIA_GPU_L4:
+  nvidia-gpu-l4:
     nodeSelector:
       cloud.google.com/gke-accelerator: "nvidia-l4"
       cloud.google.com/gke-spot: "true"

--- a/hack/dev-model.yaml
+++ b/hack/dev-model.yaml
@@ -12,7 +12,7 @@ spec:
   owner: alibaba
   url: "ollama://qwen2:0.5b"
   engine: OLlama
-  resourceProfile: CPU:1
+  resourceProfile: cpu:1
   minReplicas: 1
   maxReplicas: 3
 ---

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -53,6 +53,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 }
 
 type ResourceProfile struct {
+	ImageName    string              `json:"imageName"`
 	Requests     corev1.ResourceList `json:"requests,omitempty"`
 	Limits       corev1.ResourceList `json:"limits,omitempty"`
 	NodeSelector map[string]string   `json:"nodeSelector,omitempty"`
@@ -65,11 +66,10 @@ type MessageStream struct {
 }
 
 type ModelServers struct {
-	Ollama struct {
-		Image string `json:"image"`
-	} `json:"ollama"`
-	VLLM struct {
-		CPUImage string `json:"cpuImage"`
-		GPUImage string `json:"gpuImage"`
-	}
+	OLlama ModelServer `json:"OLlama"`
+	VLLM   ModelServer `json:"VLLM"`
+}
+
+type ModelServer struct {
+	Images map[string]string `json:"images"`
 }

--- a/internal/modelcontroller/model_controller.go
+++ b/internal/modelcontroller/model_controller.go
@@ -504,7 +504,7 @@ func (r *ModelReconciler) annotationsForModel(m *kubeaiv1.Model) map[string]stri
 func (r *ModelReconciler) applyResourceProfile(model *kubeaiv1.Model) (bool, error) {
 	split := strings.Split(model.Spec.ResourceProfile, ":")
 	if len(split) != 2 {
-		return false, fmt.Errorf("invalid resource profile: %q, should match <name>:<multiple>, example: L4:2", model.Spec.ResourceProfile)
+		return false, fmt.Errorf("invalid resource profile: %q, should match <name>:<multiple>, example: nvidia-gpu-l4:2", model.Spec.ResourceProfile)
 	}
 	name := split[0]
 	multiple, err := strconv.Atoi(split[1])

--- a/internal/modelcontroller/model_controller.go
+++ b/internal/modelcontroller/model_controller.go
@@ -220,13 +220,6 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, index int32) *corev
 	}
 	args = append(args, m.Spec.Args...)
 
-	var image string
-	if usesGPUResources(*m.Spec.Resources) {
-		image = r.ModelServers.VLLM.GPUImage
-	} else {
-		image = r.ModelServers.VLLM.CPUImage
-	}
-
 	env := []corev1.EnvVar{
 		{
 			// TODO: Conditionally set this token based on whether
@@ -266,7 +259,7 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, index int32) *corev
 			Containers: []corev1.Container{
 				{
 					Name:      "server",
-					Image:     image,
+					Image:     m.Spec.Image,
 					Args:      args,
 					Env:       env,
 					Resources: *m.Spec.Resources,
@@ -399,7 +392,7 @@ func (r *ModelReconciler) oLlamaPodForModel(m *kubeaiv1.Model, index int32) *cor
 			Containers: []corev1.Container{
 				{
 					Name:      "server",
-					Image:     r.ModelServers.Ollama.Image,
+					Image:     m.Spec.Image,
 					Args:      m.Spec.Args,
 					Env:       env,
 					Resources: *m.Spec.Resources,
@@ -508,12 +501,6 @@ func (r *ModelReconciler) annotationsForModel(m *kubeaiv1.Model) map[string]stri
 	return ann
 }
 
-func usesGPUResources(res corev1.ResourceRequirements) bool {
-	_, gpuLimits := res.Limits[corev1.ResourceName("nvidia.com/gpu")]
-	_, gpuRequests := res.Limits[corev1.ResourceName("nvidia.com/gpu")]
-	return gpuLimits || gpuRequests
-}
-
 func (r *ModelReconciler) applyResourceProfile(model *kubeaiv1.Model) (bool, error) {
 	split := strings.Split(model.Spec.ResourceProfile, ":")
 	if len(split) != 2 {
@@ -559,6 +546,37 @@ func (r *ModelReconciler) applyResourceProfile(model *kubeaiv1.Model) (bool, err
 	if !selectorsEqual(nodeSelector, model.Spec.NodeSelector) {
 		model.Spec.NodeSelector = nodeSelector
 		changed = true
+	}
+
+	if model.Spec.Image == "" {
+		var serverImgs map[string]string
+		switch model.Spec.Engine {
+		case kubeaiv1.OLlamaEngine:
+			serverImgs = r.ModelServers.OLlama.Images
+		default:
+			serverImgs = r.ModelServers.VLLM.Images
+		}
+
+		// If no image name is provided for a profile, use the default image name.
+		const defaultImageName = "default"
+		imageName := defaultImageName
+		if profile.ImageName != "" {
+			imageName = profile.ImageName
+		}
+
+		if img, ok := serverImgs[imageName]; ok {
+			model.Spec.Image = img
+			changed = true
+		} else {
+			// If the specific profile image name does not exist, use the default image name.
+			if img, ok := serverImgs[defaultImageName]; ok {
+				model.Spec.Image = img
+				changed = true
+			} else {
+				return false, fmt.Errorf("missing default server image")
+			}
+		}
+
 	}
 
 	return changed, nil


### PR DESCRIPTION
Define imageNames for given model servers, reference imageNames in resourceProfiles.

Switch reference resource profiles to be lowercase to support the possibility of introducing a ResourceProfile CRD in the future (would require a lowercase .metadata.name).

Fixes #152 via a different technique.