### PR TITLE
Tweak doc titles, add "make docs", change indigo color to white, add docs about docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,15 @@ golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
+.PHONY: docs
+docs:
+	cd ./docs && \
+		python3 -m venv .venv && \
+		source .venv/bin/activate && \
+		pip install -r requirements.txt && \
+		cd .. && \
+		mkdocs serve
+
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary
 # $2 - package url which can be installed

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@ Any vLLM or Ollama model can be served by KubeAI. Some examples of popular model
 
 ## Documentation
 
-Checkout the our documenation on [kubeai.org](https://www.kubeai.org) to find info on:
+Checkout our documenation on [kubeai.org](https://www.kubeai.org) to find info on:
 
 * Installing KubeAI in the cloud
 * How to guides (e.g. how to manage models and resource profiles).

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,13 +107,12 @@ Any vLLM or Ollama model can be served by KubeAI. Some examples of popular model
 
 ## Documentation
 
-Checkout the [docs](https://www.kubeai.org) at [kubeai.org](https://www.kubeai.org) for more information.
+Checkout the our documenation on [kubeai.org](https://www.kubeai.org) to find info on:
 
-The docs have the following content:
-* Environment Installation Guides (e.g. GKE).
+* Installing KubeAI in the cloud
 * How to guides (e.g. how to manage models and resource profiles).
-* Concept (e.g. explain how Model and Resource Profile work).
-* Contributor Guide
+* Concepts (how the components of KubeAI work).
+* How to contribute
 
 ## OpenAI API Compatibility
 

--- a/docs/contributing/development-environment.md
+++ b/docs/contributing/development-environment.md
@@ -1,4 +1,4 @@
-# How to setup a development environment
+# Development environment
 
 This document provides instructions for setting up an environment for developing KubeAI.
 

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -1,0 +1,23 @@
+# Documentation
+
+We are grateful for anyone who takes the time to improve KubeAI documentation! In order to keep our docs clear and consistent we ask that you first read about the approach to documentation that we have standardized on...
+
+## Read before writing!
+
+The KubeAI approach to documentation is loosely inspired by the [Diataxis](https://diataxis.fr/) method.
+
+TLDR on how KubeAI docs are organized:
+
+* **Installation**: How-to guides specific to installing KubeAI.
+* **How To**: Directions that guide the reader through a problem or towards a result. How-to guides are goal-oriented. They assume the user is familiar with general concepts, tools, and has already installed KubeAI.
+* **Concepts**: A reflective explanation of KubeAI topics with a focus on giving the reader an understanding of the why.
+* **Tutorials**: Learning oriented experiences. Lessons that often guide a user from beginning to end. The goal is to help the reader *learn* something (compared to a how-to guide that is focused on helping the reader *do* something).
+* **Contributing**: The docs in here differ from the rest of the docs by audience: these docs are for anyone who will be contributing code or docs to the KubeAI project.
+
+## How to serve kubeai.org locally
+
+Make sure you have python3 installed and run:
+
+```bash
+make docs
+```

--- a/docs/how-to/manage-models.md
+++ b/docs/how-to/manage-models.md
@@ -1,4 +1,4 @@
-# How to manage models
+# Manage models
 
 This guide provides instructions on how to perform CRUD operations on KubeAI [Models](../concepts/models.md).
 

--- a/docs/how-to/manage-resource-profiles.md
+++ b/docs/how-to/manage-resource-profiles.md
@@ -1,4 +1,4 @@
-# How to manage resource profiles
+# Manage resource profiles
 
 This guide will cover modifying preconfigured [resource profiles](../concepts/resource-profiles.md) and adding your own.
 

--- a/docs/installation/gke.md
+++ b/docs/installation/gke.md
@@ -1,7 +1,3 @@
----
-nav: GKE
----
-
 # Install on GKE
 
 <details markdown="1">

--- a/docs/installation/gke.md
+++ b/docs/installation/gke.md
@@ -1,8 +1,8 @@
 ---
-title: "Install KubeAI on GKE"
+nav: GKE
 ---
 
-# Install KubeAI on GKE
+# Install on GKE
 
 <details markdown="1">
 <summary>TIP: Make sure you have enough quota in your GCP project.</summary>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,12 @@
 site_name: KubeAI
 site_url: https://www.kubeai.org
 repo_url: https://github.com/substratusai/kubeai
+
 theme:
   name: material
+  palette:
+    primary: black
+
 nav:
   - Home: README.md
   - ... | installation/*.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,8 @@ repo_url: https://github.com/substratusai/kubeai
 theme:
   name: material
   palette:
-    primary: black
+    primary: white # Defaults to indigo.
+    accent: blue # Defaults to indigo.
 
 nav:
   - Home: README.md


### PR DESCRIPTION
* `make docs` now serves `kubeai.org` locally.
* Small tweaks to doc titles so that the sidebar looks more cohesive:

<img width="242" alt="Screenshot 2024-09-01 at 9 48 46 PM" src="https://github.com/user-attachments/assets/d83e657a-ebe6-44b3-ae7b-344469795393">

* Added a contributing doc about documentation.

* Also updated the "Documentation" section in the README.md which was not rendering correctly via mkdocs:

**Previous:**

<img width="725" alt="Screenshot 2024-09-01 at 9 53 14 PM" src="https://github.com/user-attachments/assets/5c64e05d-93d4-4a4e-8c3a-749b86d1e536">

**Updated:**

<img width="548" alt="Screenshot 2024-09-01 at 9 58 44 PM" src="https://github.com/user-attachments/assets/92fb28a4-4bec-4a2d-8ccf-48b4ef1cdfb2">

* Change color scheme to white:

<img width="1238" alt="Screenshot 2024-09-01 at 10 47 01 PM" src="https://github.com/user-attachments/assets/0be042dc-0fce-4994-95be-b28846d0a1bd">


