### PR TITLE
Fix Huggingface default Secret name

### DIFF
--- a/charts/kubeai/Chart.yaml
+++ b/charts/kubeai/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kubeai/templates/_helpers.tpl
+++ b/charts/kubeai/templates/_helpers.tpl
@@ -66,7 +66,11 @@ Create the name of the huggingface secret to use
 */}}
 {{- define "kubeai.huggingfaceSecretName" -}}
 {{- if .Values.secrets.huggingface.create -}}
-{{- default (include "kubeai.fullname" .) .Values.secrets.huggingface.name }}
+{{- if .Values.secrets.huggingface.name -}}
+{{- .Values.secrets.huggingface.name -}}
+{{- else }}
+{{- (include "kubeai.fullname" .)}}-huggingface
+{{- end}}
 {{- else }}
 {{- if not .Values.secrets.huggingface.name -}}
 {{ fail "if secrets.huggingface.create is false, secrets.huggingface.name is required" }}


### PR DESCRIPTION
Huggingface Secret name should be specific to "huggingface", I think this was a regression from #133 

```bash
(base) ➜  kubeai git:(main) helm template kubeai ./charts/kubeai | grep -A 2 Secret
kind: Secret
metadata:
  name: kubeai # OLD NAME
(base) ➜  kubeai git:(main) git checkout -
Switched to branch 'fix-huggingface-secret-name'
Your branch is up to date with 'origin/fix-huggingface-secret-name'.
(base) ➜  kubeai git:(fix-huggingface-secret-name) helm template kubeai ./charts/kubeai | grep -A 2 Secret
kind: Secret
metadata:
  name: kubeai-huggingface # NEW NAME
```