### PR TITLE
fix quickstart e2e test flakiness

### DIFF
--- a/test/quickstart.sh
+++ b/test/quickstart.sh
@@ -80,6 +80,10 @@ models:
       minReplicas: 1
 EOF
 
+
+# wait for kubeai pod to be ready after helm upgrade.
+sleep 10
+wait_for_pod_ready app.kubernetes.io/name=kubeai
 wait_for_pod_ready model=gemma2-2b-cpu
 
 curl -s -X GET "http://localhost:8000/openai/v1/models" | jq '. | length == 4'


### PR DESCRIPTION
Ocasionally the kubeai pod isn't recreated and ready yet after executing helm upgrade with new models.

This fixes it by adding a small sleep and a wait for the kubeai pod.