### PR TITLE
Recreate KubeAI Pods on change to ConfigMap & add missing ConfigMap field

### DIFF
--- a/charts/kubeai/templates/configmap.yaml
+++ b/charts/kubeai/templates/configmap.yaml
@@ -14,3 +14,5 @@ data:
       {{- .Values.modelServers | toYaml | nindent 6 }}
     modelAutoscaling:
       {{- .Values.modelAutoscaling | toYaml | nindent 6 }}
+    messaging:
+      {{- .Values.messaging | toYaml | nindent 6 }}

--- a/charts/kubeai/templates/deployment.yaml
+++ b/charts/kubeai/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        # Recreate Pods on update to ConfigMap b/c hot reload is not supported.
+        # Recreate Pods on update of ConfigMap b/c hot reload is not supported.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/kubeai/templates/deployment.yaml
+++ b/charts/kubeai/templates/deployment.yaml
@@ -11,8 +11,10 @@ spec:
       {{- include "kubeai.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Recreate Pods on update to ConfigMap b/c hot reload is not supported.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Restart KubeAI to pick up changes to configmap.
See: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

Hot-reload was considered - however it gets complicated b/c of long-running processes that get started such as messengers and autoscaling. We can punt on that until later.

Related to #151 which can be implemented seperately.

Also added `.messaging` to ConfigMap (it was omitted).