### PR TITLE
Add support for OpenShift

### DIFF
--- a/charts/kubeai/charts/openwebui/templates/securityContextConstraints.yaml
+++ b/charts/kubeai/charts/openwebui/templates/securityContextConstraints.yaml
@@ -1,0 +1,20 @@
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+{{- if .Values.serviceAccount.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: openwebui
+allowPrivilegeEscalation: false
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+  - runtime/default
+requiredDropCapabilities:
+  - ALL
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ include "openwebui.serviceAccountName" . }}
+{{- end }}
+{{- end }}

--- a/charts/kubeai/charts/openwebui/templates/securityContextConstraints.yaml
+++ b/charts/kubeai/charts/openwebui/templates/securityContextConstraints.yaml
@@ -1,9 +1,12 @@
+# Create securityContextConstraints for the openwebui pod if running on OpenShift.
+# This is needed because pods in OpenShift run with the restricted-v2 SCC by
+# default which do not allow a container to start with uid=0
+# (The openwebui image runs as the root user)
 {{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
-{{- if .Values.serviceAccount.create }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: openwebui
+  name: {{ include "openwebui.fullname" . }}
 allowPrivilegeEscalation: false
 readOnlyRootFilesystem: false
 runAsUser:
@@ -16,5 +19,4 @@ requiredDropCapabilities:
   - ALL
 users:
   - system:serviceaccount:{{ .Release.Namespace }}:{{ include "openwebui.serviceAccountName" . }}
-{{- end }}
 {{- end }}

--- a/charts/kubeai/templates/_helpers.tpl
+++ b/charts/kubeai/templates/_helpers.tpl
@@ -62,6 +62,17 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the service account to use for model pods
+*/}}
+{{- define "models.serviceAccountName" -}}
+{{- if .Values.modelServiceAccount.create }}
+{{- default (printf "%s-models" (include "kubeai.fullname" .)) .Values.modelServiceAccount.name }}
+{{- else }}
+{{- default "default" .Values.modelServiceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the huggingface secret to use
 */}}
 {{- define "kubeai.huggingfaceSecretName" -}}

--- a/charts/kubeai/templates/configmap.yaml
+++ b/charts/kubeai/templates/configmap.yaml
@@ -22,9 +22,7 @@ data:
       securityContext:
         {{- .Values.modelServerPods.securityContext | toYaml | nindent 8}}
       {{- end}}
-      {{- if .Values.modelServiceAccount.create }}
       serviceAccountName: {{ include "models.serviceAccountName" . }}
-      {{- end}}
     {{- end }}
     modelAutoscaling:
       {{- .Values.modelAutoscaling | toYaml | nindent 6 }}

--- a/charts/kubeai/templates/configmap.yaml
+++ b/charts/kubeai/templates/configmap.yaml
@@ -12,6 +12,20 @@ data:
       {{- .Values.resourceProfiles | toYaml | nindent 6 }}
     modelServers:
       {{- .Values.modelServers | toYaml | nindent 6 }}
+    {{- if .Values.modelServerPods }}
+    modelServerPods:
+      {{- if .Values.modelServerPods.podSecurityContext }}
+      podSecurityContext:
+        {{- .Values.modelServerPods.podSecurityContext | toYaml | nindent 8}}
+      {{- end}}
+      {{- if .Values.modelServerPods.securityContext }}
+      securityContext:
+        {{- .Values.modelServerPods.securityContext | toYaml | nindent 8}}
+      {{- end}}
+      {{- if .Values.modelServiceAccount.create }}
+      serviceAccountName: {{ include "models.serviceAccountName" . }}
+      {{- end}}
+    {{- end }}
     modelAutoscaling:
       {{- .Values.modelAutoscaling | toYaml | nindent 6 }}
     messaging:

--- a/charts/kubeai/templates/configmap.yaml
+++ b/charts/kubeai/templates/configmap.yaml
@@ -12,8 +12,8 @@ data:
       {{- .Values.resourceProfiles | toYaml | nindent 6 }}
     modelServers:
       {{- .Values.modelServers | toYaml | nindent 6 }}
-    {{- if .Values.modelServerPods }}
     modelServerPods:
+      {{- if .Values.modelServerPods }}
       {{- if .Values.modelServerPods.podSecurityContext }}
       podSecurityContext:
         {{- .Values.modelServerPods.podSecurityContext | toYaml | nindent 8}}
@@ -22,8 +22,8 @@ data:
       securityContext:
         {{- .Values.modelServerPods.securityContext | toYaml | nindent 8}}
       {{- end}}
+      {{- end}}
       serviceAccountName: {{ include "models.serviceAccountName" . }}
-    {{- end }}
     modelAutoscaling:
       {{- .Values.modelAutoscaling | toYaml | nindent 6 }}
     messaging:

--- a/charts/kubeai/templates/securityContextConstraints.yaml
+++ b/charts/kubeai/templates/securityContextConstraints.yaml
@@ -1,9 +1,12 @@
+# Create securityContextConstraints for the model pods if running on OpenShift.
+# This is needed because pods in OpenShift run with the restricted-v2 SCC by
+# default which do not allow a container to start with uid=0
+# (The model pod images run as the root user)
 {{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
-{{- if .Values.modelServiceAccount.create -}}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: kubeai-models
+  name: {{ include "kubeai.fullname" . }}-models
 allowPrivilegeEscalation: false
 readOnlyRootFilesystem: false
 runAsUser:
@@ -16,5 +19,4 @@ requiredDropCapabilities:
   - ALL
 users:
   - system:serviceaccount:{{ .Release.Namespace }}:{{ include "models.serviceAccountName" . }}
-{{- end }}
 {{- end }}

--- a/charts/kubeai/templates/securityContextConstraints.yaml
+++ b/charts/kubeai/templates/securityContextConstraints.yaml
@@ -1,5 +1,5 @@
 {{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.modelServiceAccount.create -}}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:

--- a/charts/kubeai/templates/securityContextConstraints.yaml
+++ b/charts/kubeai/templates/securityContextConstraints.yaml
@@ -1,0 +1,20 @@
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+{{- if .Values.serviceAccount.create -}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: kubeai-models
+allowPrivilegeEscalation: false
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+  - runtime/default
+requiredDropCapabilities:
+  - ALL
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ include "models.serviceAccountName" . }}
+{{- end }}
+{{- end }}

--- a/charts/kubeai/templates/serviceaccount.yaml
+++ b/charts/kubeai/templates/serviceaccount.yaml
@@ -11,3 +11,17 @@ metadata:
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}
+{{- if .Values.modelServiceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "models.serviceAccountName" . }}
+  labels:
+    {{- include "kubeai.labels" . | nindent 4 }}
+  {{- with .Values.modelServiceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.modelServiceAccount.automount }}
+{{- end }}

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -30,6 +30,17 @@ modelServers:
       default: "fedirz/faster-whisper-server:latest-cpu"
       nvidia-gpu: "fedirz/faster-whisper-server:latest-cuda"
 
+modelServerPods:
+  # Security Context for the model pods
+  # Needed for OpenShift
+  securityContext:
+    runAsUser: 0
+    readOnlyRootFilesystem: false
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
 resourceProfiles:
   cpu:
     imageName: "cpu"
@@ -97,6 +108,15 @@ openwebui:
     value: "true"
   - name: ENABLE_LITELLM
     value: "false"
+  # Security Context for the openwebui pod
+  # Needed for OpenShift
+  securityContext:
+    runAsUser: 0
+    readOnlyRootFilesystem: false
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
 replicaCount: 1
 
@@ -123,6 +143,16 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+modelServiceAccount:
+  # Specifies whether a service account should be created to be used by model pods
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -31,6 +31,8 @@ type System struct {
 	AllowPodAddressOverride bool `json:"allowPodAddressOverride"`
 
 	ModelAutoscaling ModelAutoscaling `json:"modelAutoscaling" validate:"required"`
+
+	ModelServerPods ModelServerPods `json:"modelServerPods,omitempty"`
 }
 
 func (s *System) DefaultAndValidate() error {
@@ -145,4 +147,15 @@ type ModelServers struct {
 
 type ModelServer struct {
 	Images map[string]string `json:"images"`
+}
+
+type ModelServerPods struct {
+	// The service account to use for all model pods
+	ModelServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// Security Context for the model pods
+	ModelPodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+
+	// Security Context for the model pod containers
+	ModelContainerSecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -168,6 +168,7 @@ func Run(ctx context.Context, k8sCfg *rest.Config, cfg config.System) error {
 		HuggingfaceSecretName:   cfg.SecretNames.Huggingface,
 		ResourceProfiles:        cfg.ResourceProfiles,
 		ModelServers:            cfg.ModelServers,
+		ModelServerPods:         cfg.ModelServerPods,
 	}
 	if err = modelReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create Model controller: %w", err)

--- a/internal/modelcontroller/model_controller.go
+++ b/internal/modelcontroller/model_controller.go
@@ -50,6 +50,7 @@ type ModelReconciler struct {
 	HuggingfaceSecretName   string
 	ResourceProfiles        map[string]config.ResourceProfile
 	ModelServers            config.ModelServers
+	ModelServerPods         config.ModelServerPods
 }
 
 // +kubebuilder:rbac:groups=kubeai.org,resources=models,verbs=get;list;watch;create;update;patch;delete
@@ -250,15 +251,18 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, profile ModelConfig
 			Annotations: ann,
 		},
 		Spec: corev1.PodSpec{
-			NodeSelector: profile.NodeSelector,
-			Affinity:     profile.Affinity,
-			Tolerations:  profile.Tolerations,
+			NodeSelector:       profile.NodeSelector,
+			SecurityContext:    r.ModelServerPods.ModelPodSecurityContext,
+			ServiceAccountName: r.ModelServerPods.ModelServiceAccountName,
+			Affinity:           profile.Affinity,
+			Tolerations:        profile.Tolerations,
 			Containers: []corev1.Container{
 				{
-					Name:  "server",
-					Image: profile.Image,
-					Args:  args,
-					Env:   env,
+					Name:            "server",
+					Image:           profile.Image,
+					Args:            args,
+					Env:             env,
+					SecurityContext: r.ModelServerPods.ModelContainerSecurityContext,
 					Resources: corev1.ResourceRequirements{
 						Requests: profile.Requests,
 						Limits:   profile.Limits,
@@ -400,15 +404,18 @@ func (r *ModelReconciler) oLlamaPodForModel(m *kubeaiv1.Model, profile ModelConf
 			Annotations: ann,
 		},
 		Spec: corev1.PodSpec{
-			NodeSelector: profile.NodeSelector,
-			Affinity:     profile.Affinity,
-			Tolerations:  profile.Tolerations,
+			NodeSelector:       profile.NodeSelector,
+			SecurityContext:    r.ModelServerPods.ModelPodSecurityContext,
+			ServiceAccountName: r.ModelServerPods.ModelServiceAccountName,
+			Affinity:           profile.Affinity,
+			Tolerations:        profile.Tolerations,
 			Containers: []corev1.Container{
 				{
-					Name:  "server",
-					Image: profile.Image,
-					Args:  m.Spec.Args,
-					Env:   env,
+					Name:            "server",
+					Image:           profile.Image,
+					Args:            m.Spec.Args,
+					Env:             env,
+					SecurityContext: r.ModelServerPods.ModelContainerSecurityContext,
 					Resources: corev1.ResourceRequirements{
 						Requests: profile.Requests,
 						Limits:   profile.Limits,
@@ -546,15 +553,18 @@ func (r *ModelReconciler) fasterWhisperPodForModel(m *kubeaiv1.Model, profile Mo
 			Annotations: ann,
 		},
 		Spec: corev1.PodSpec{
-			NodeSelector: profile.NodeSelector,
-			Affinity:     profile.Affinity,
-			Tolerations:  profile.Tolerations,
+			NodeSelector:       profile.NodeSelector,
+			SecurityContext:    r.ModelServerPods.ModelPodSecurityContext,
+			ServiceAccountName: r.ModelServerPods.ModelServiceAccountName,
+			Affinity:           profile.Affinity,
+			Tolerations:        profile.Tolerations,
 			Containers: []corev1.Container{
 				{
-					Name:  "server",
-					Image: profile.Image,
-					Args:  args,
-					Env:   env,
+					Name:            "server",
+					Image:           profile.Image,
+					Args:            args,
+					Env:             env,
+					SecurityContext: r.ModelServerPods.ModelContainerSecurityContext,
 					Resources: corev1.ResourceRequirements{
 						Requests: profile.Requests,
 						Limits:   profile.Limits,


### PR DESCRIPTION
OpenShift requires securityContext to be set for pods in order to decide an appropriate SCC to apply to them.

This PR:

1. Adds SecurityContext for the model pods created by kubeAI
2. Adds SecurityContext for the model containers created by kubeAI
3. Sets securityContext for openwebui container
4. Creates securityContextConstraints (SCC) for openwebui and the model pods

Chart version fields are untouched... not sure what to do with them