### PR TITLE
Automatically roll out changes to Models

### DIFF
--- a/api/v1/constants.go
+++ b/api/v1/constants.go
@@ -2,8 +2,8 @@ package v1
 
 const (
 	PodModelLabel = "model"
-	// PodSpecHashLabel is a label key used to store the hash of the Pod spec.
-	// That was used to create the Pod. This is used to determine if a Pod
+	// PodSpecHashLabel is a label key used to store the hash of the Pod spec
+	// that was used to create the Pod. This is used to determine if a Pod
 	// needs to be recreated.
 	PodSpecHashLabel = "pod-spec-hash"
 

--- a/api/v1/constants.go
+++ b/api/v1/constants.go
@@ -2,6 +2,10 @@ package v1
 
 const (
 	PodModelLabel = "model"
+	// PodSpecHashLabel is a label key used to store the hash of the Pod spec.
+	// That was used to create the Pod. This is used to determine if a Pod
+	// needs to be recreated.
+	PodSpecHashLabel = "pod-spec-hash"
 
 	ModelFeatureLabelDomain = "features.kubeai.org"
 

--- a/api/v1/constants.go
+++ b/api/v1/constants.go
@@ -2,10 +2,10 @@ package v1
 
 const (
 	PodModelLabel = "model"
-	// PodSpecHashLabel is a label key used to store the hash of the Pod spec
+	// PodHashLabel is a label key used to store the hash of the Pod spec
 	// that was used to create the Pod. This is used to determine if a Pod
 	// needs to be recreated.
-	PodSpecHashLabel = "pod-spec-hash"
+	PodHashLabel = "pod-hash"
 
 	ModelFeatureLabelDomain = "features.kubeai.org"
 

--- a/docs/how-to/configure-autoscaling.md
+++ b/docs/how-to/configure-autoscaling.md
@@ -20,8 +20,6 @@ modelAutoscaling:
 
 The following settings can be configured on a model-by-model basis.
 
-**NOTE:** Updates to model settings will be applied upon scale up of additional model Pods. You can force-restart model servers by running `kubectl delete pods -l model=<model-name>`.
-
 ### Model settings: helm
 
 If you are managing models via the `kubeai/models` Helm chart, you can use:

--- a/internal/k8sutils/meta.go
+++ b/internal/k8sutils/meta.go
@@ -1,0 +1,37 @@
+package k8sutils
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+func ApplyLabel(obj client.Object, key, value string) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+		obj.SetLabels(labels)
+	}
+	labels[key] = value
+}
+
+func ApplyAnnotation(obj client.Object, key, value string) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+		obj.SetAnnotations(annotations)
+	}
+	annotations[key] = value
+}
+
+func GetLabel(obj client.Object, key string) string {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return ""
+	}
+	return labels[key]
+}
+
+func GetAnnotation(obj client.Object, key string) string {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+	return annotations[key]
+}

--- a/internal/k8sutils/meta.go
+++ b/internal/k8sutils/meta.go
@@ -2,7 +2,7 @@ package k8sutils
 
 import "sigs.k8s.io/controller-runtime/pkg/client"
 
-func ApplyLabel(obj client.Object, key, value string) {
+func SetLabel(obj client.Object, key, value string) {
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)
@@ -11,7 +11,7 @@ func ApplyLabel(obj client.Object, key, value string) {
 	labels[key] = value
 }
 
-func ApplyAnnotation(obj client.Object, key, value string) {
+func SetAnnotation(obj client.Object, key, value string) {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)

--- a/internal/k8sutils/meta_test.go
+++ b/internal/k8sutils/meta_test.go
@@ -1,0 +1,81 @@
+package k8sutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestSetLabel(t *testing.T) {
+	t.Parallel()
+	const (
+		testKey = "test-key"
+		testVal = "test-val"
+	)
+	cases := []struct {
+		name     string
+		input    client.Object
+		expected client.Object
+	}{
+		{
+			name:     "nil labels",
+			input:    &corev1.Pod{},
+			expected: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{testKey: testVal}}},
+		},
+		{
+			name:     "existing labels",
+			input:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"existing-key": "existing-val", testKey: testVal}}},
+			expected: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"existing-key": "existing-val", testKey: testVal}}},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			SetLabel(c.input, testKey, testVal)
+			assert.Equal(t, c.expected, c.input)
+		})
+	}
+}
+
+func TestGetLabel(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"test-key": "test-val"}}}
+	assert.Equal(t, "test-val", GetLabel(pod, "test-key"))
+}
+
+func TestSetAnnotation(t *testing.T) {
+	t.Parallel()
+	const (
+		testKey = "test-key"
+		testVal = "test-val"
+	)
+	cases := []struct {
+		name     string
+		input    client.Object
+		expected client.Object
+	}{
+		{
+			name:     "nil annotations",
+			input:    &corev1.Pod{},
+			expected: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{testKey: testVal}}},
+		},
+		{
+			name:     "existing annotations",
+			input:    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"existing-key": "existing-val", testKey: testVal}}},
+			expected: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"existing-key": "existing-val", testKey: testVal}}},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			SetAnnotation(c.input, testKey, testVal)
+			assert.Equal(t, c.expected, c.input)
+		})
+	}
+}
+func TestGetAnnotation(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"test-key": "test-val"}}}
+	assert.Equal(t, "test-val", GetAnnotation(pod, "test-key"))
+}

--- a/internal/k8sutils/pods.go
+++ b/internal/k8sutils/pods.go
@@ -19,10 +19,9 @@ func PodIsReady(pod *corev1.Pod) bool {
 	return false
 }
 
-// PodHash returns a hash value calculated from Pod spec and
-// a collisionCount to avoid hash collision.
+// PodHash returns a hash value calculated from Pod spec.
 // Inspired by k8s.io/kubernetes/pkg/controller.ComputeHash()
-func PodHash(podSpec corev1.PodSpec, collisionCount *int32) string {
+func PodHash(podSpec corev1.PodSpec) string {
 	podTemplateSpecHasher := fnv.New32a()
 	DeepHashObject(podTemplateSpecHasher, podSpec)
 

--- a/internal/k8sutils/pods.go
+++ b/internal/k8sutils/pods.go
@@ -1,7 +1,13 @@
 package k8sutils
 
 import (
+	"fmt"
+	"hash"
+	"hash/fnv"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/dump"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 func PodIsReady(pod *corev1.Pod) bool {
@@ -11,4 +17,31 @@ func PodIsReady(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// PodHash returns a hash value calculated from Pod spec and
+// a collisionCount to avoid hash collision.
+// Inspired by k8s.io/kubernetes/pkg/controller.ComputeHash()
+func PodHash(podSpec corev1.PodSpec, collisionCount *int32) string {
+	podTemplateSpecHasher := fnv.New32a()
+	DeepHashObject(podTemplateSpecHasher, podSpec)
+
+	// TODO: Implement collision detection if needed.
+	//// Add collisionCount in the hash if it exists.
+	//if collisionCount != nil {
+	//	collisionCountBytes := make([]byte, 8)
+	//	binary.LittleEndian.PutUint32(collisionCountBytes, uint32(*collisionCount))
+	//	podTemplateSpecHasher.Write(collisionCountBytes)
+	//}
+
+	return rand.SafeEncodeString(fmt.Sprint(podTemplateSpecHasher.Sum32()))
+}
+
+// DeepHashObject writes specified object to hash using the spew library
+// which follows pointers and prints actual values of the nested objects
+// ensuring the hash does not change when a pointer changes.
+// Copied from k8s.io/kubernetes/pkg/util/hash to avoid dependency on k8s.io/kubernetes.
+func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	fmt.Fprintf(hasher, "%v", dump.ForHash(objectToWrite))
 }

--- a/internal/modelcontroller/model_controller.go
+++ b/internal/modelcontroller/model_controller.go
@@ -579,7 +579,7 @@ func (r *ModelReconciler) fasterWhisperPodForModel(m *kubeaiv1.Model, profile Mo
 	return pod
 }
 
-func (r *ModelReconciler) infinityPodForModel(m *kubeaiv1.Model, profile ModelConfig, index int32) *corev1.Pod {
+func (r *ModelReconciler) infinityPodForModel(m *kubeaiv1.Model, profile ModelConfig, name string) *corev1.Pod {
 	lbs := labelsForModel(m)
 	ann := r.annotationsForModel(m)
 
@@ -644,7 +644,7 @@ func (r *ModelReconciler) infinityPodForModel(m *kubeaiv1.Model, profile ModelCo
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        fmt.Sprintf("model-%s-%d", m.Name, index),
+			Name:        name,
 			Namespace:   m.Namespace,
 			Labels:      lbs,
 			Annotations: ann,

--- a/internal/modelcontroller/pods.go
+++ b/internal/modelcontroller/pods.go
@@ -28,6 +28,8 @@ func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubea
 		podForModel = r.oLlamaPodForModel
 	case kubeaiv1.FasterWhisperEngine:
 		podForModel = r.fasterWhisperPodForModel
+	case kubeaiv1.InfinityEngine:
+		podForModel = r.infinityPodForModel
 	default:
 		podForModel = r.vLLMPodForModel
 	}

--- a/internal/modelcontroller/pods.go
+++ b/internal/modelcontroller/pods.go
@@ -17,12 +17,10 @@ import (
 
 func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubeaiv1.Model, modelConfig ModelConfig) *podPlan {
 	var desiredReplicas int32
-	// Replicas could be nil if autoscaling is disabled.
+	// NOTE: Replicas could be nil if autoscaling is disabled.
 	if model.Spec.Replicas != nil {
 		desiredReplicas = *model.Spec.Replicas
 	}
-
-	// TODO: Take into account Pods that are in a deletion state.
 
 	var podForModel func(*kubeaiv1.Model, ModelConfig, string) *corev1.Pod
 	switch model.Spec.Engine {

--- a/internal/modelcontroller/pods.go
+++ b/internal/modelcontroller/pods.go
@@ -54,7 +54,7 @@ func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubea
 		expectedPod := podForModel(model, modelConfig, name)
 		// TODO: If collisions become an issue, we can add a Model.Status.CollisionCount (new field)
 		// to the PodHash call.
-		expectedPodHash := k8sutils.PodHash(expectedPod.Spec, nil)
+		expectedPodHash := k8sutils.PodHash(expectedPod.Spec)
 		k8sutils.SetLabel(expectedPod, kubeaiv1.PodHashLabel, expectedPodHash)
 
 		currentPod, ok := podMap[name]

--- a/internal/modelcontroller/pods.go
+++ b/internal/modelcontroller/pods.go
@@ -53,7 +53,7 @@ func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubea
 		// TODO: If collisions become an issue, we can add a Model.Status.CollisionCount (new field)
 		// to the PodHash call.
 		expectedPodHash := k8sutils.PodHash(expectedPod.Spec, nil)
-		k8sutils.SetLabel(expectedPod, kubeaiv1.PodSpecHashLabel, expectedPodHash)
+		k8sutils.SetLabel(expectedPod, kubeaiv1.PodHashLabel, expectedPodHash)
 
 		currentPod, ok := podMap[name]
 		if ok {
@@ -63,7 +63,7 @@ func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubea
 			// This is probably OK for now since the proxy will handle
 			// the queuing of incoming requests until the new Pods are ready.
 			// (albeit with some failures).
-			if k8sutils.GetLabel(&currentPod, kubeaiv1.PodSpecHashLabel) != expectedPodHash {
+			if k8sutils.GetLabel(&currentPod, kubeaiv1.PodHashLabel) != expectedPodHash {
 				toDelete = append(toDelete, &currentPod)
 				toCreate = append(toCreate, expectedPod)
 			}

--- a/internal/modelcontroller/pods.go
+++ b/internal/modelcontroller/pods.go
@@ -53,7 +53,7 @@ func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubea
 		// TODO: If collisions become an issue, we can add a Model.Status.CollisionCount (new field)
 		// to the PodHash call.
 		expectedPodHash := k8sutils.PodHash(expectedPod.Spec, nil)
-		k8sutils.ApplyLabel(expectedPod, kubeaiv1.PodSpecHashLabel, expectedPodHash)
+		k8sutils.SetLabel(expectedPod, kubeaiv1.PodSpecHashLabel, expectedPodHash)
 
 		currentPod, ok := podMap[name]
 		if ok {

--- a/internal/modelcontroller/pods.go
+++ b/internal/modelcontroller/pods.go
@@ -1,0 +1,102 @@
+package modelcontroller
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	kubeaiv1 "github.com/substratusai/kubeai/api/v1"
+	"github.com/substratusai/kubeai/internal/k8sutils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubeaiv1.Model, modelConfig ModelConfig) *podPlan {
+	var scaleDesired int32
+	// Replicas could be nil if autoscaling is disabled.
+	if model.Spec.Replicas != nil {
+		scaleDesired = *model.Spec.Replicas
+	}
+	scaleActual := int32(len(allPods.Items))
+	scaleDiff := scaleActual - scaleDesired
+	scaleDiffAbs := int32(math.Abs(float64(scaleDiff)))
+
+	// TODO: Take into account Pods that are in a deletion state.
+
+	var podForModel func(*kubeaiv1.Model, ModelConfig, int32) *corev1.Pod
+	switch model.Spec.Engine {
+	case kubeaiv1.OLlamaEngine:
+		podForModel = r.oLlamaPodForModel
+	case kubeaiv1.FasterWhisperEngine:
+		podForModel = r.fasterWhisperPodForModel
+	default:
+		podForModel = r.vLLMPodForModel
+	}
+
+	var (
+		toCreate []*corev1.Pod
+		toDelete []*corev1.Pod
+	)
+
+	switch {
+	case scaleDiff == 0:
+		// At correct scale.
+	case scaleDiff < 0:
+		for i := int32(0); i < scaleDiffAbs; i++ {
+			toCreate = append(toCreate, podForModel(model, modelConfig, scaleActual+i))
+		}
+	case scaleDiff > 0:
+		toDeleteCount := scaleDiffAbs
+		for _, pod := range allPods.Items {
+			if toDeleteCount == 0 {
+				break
+			}
+			toDelete = append(toDelete, &pod)
+			toDeleteCount--
+		}
+	}
+
+	return &podPlan{
+		model:    model,
+		toCreate: toCreate,
+		toDelete: toDelete,
+	}
+}
+
+type podPlan struct {
+	model    *kubeaiv1.Model
+	toCreate []*corev1.Pod
+	toDelete []*corev1.Pod
+}
+
+func (pp *podPlan) execute(ctx context.Context, client client.Client, scheme *runtime.Scheme) error {
+	log := log.FromContext(ctx)
+
+	for _, pod := range pp.toCreate {
+		if err := ctrl.SetControllerReference(pp.model, pod, scheme); err != nil {
+			return fmt.Errorf("setting controller reference: %w", err)
+		}
+		log.Info("Creating Pod", "podName", pod.Name)
+		if err := client.Create(ctx, pod, k8sutils.DefaultCreateOptions()); err != nil {
+			return fmt.Errorf("creating pod: %w", err)
+		}
+	}
+
+	for _, pod := range pp.toDelete {
+		log.Info("Deleting Pod", "podName", pod.Name)
+		if err := client.Delete(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: pod.Namespace,
+				Name:      pod.Name,
+			},
+		}); err != nil {
+			return fmt.Errorf("deleting pod: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/test/integration/model_pod_recovery_test.go
+++ b/test/integration/model_pod_recovery_test.go
@@ -1,0 +1,42 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestModelPodRecovery tests that if a Pod is deleted, it is recreated
+// with the same name.
+func TestModelPodRecovery(t *testing.T) {
+	// Create a Model object.
+	m := modelForTest(t)
+	m.Spec.MinReplicas = 3
+	m.Spec.MaxReplicas = ptr.To[int32](3)
+
+	require.NoError(t, testK8sClient.Create(testCtx, m))
+
+	// Expect 3 Pods to be created.
+	requireModelPods(t, m, 3, "3 Pods should be created", 2*time.Second)
+
+	// Delete pod-1.
+	pod1 := &corev1.Pod{}
+	require.NoError(t, testK8sClient.Get(testCtx, client.ObjectKey{Namespace: testNS, Name: "model-" + m.Name + "-1"}, pod1))
+	require.NoError(t, testK8sClient.Delete(testCtx, pod1))
+	origUID := pod1.UID
+
+	require.Eventually(t, func() bool {
+		newPod1 := &corev1.Pod{}
+		if !assert.NoError(t, testK8sClient.Get(testCtx, client.ObjectKey{Namespace: testNS, Name: "model-" + m.Name + "-1"}, newPod1)) {
+			return false
+		}
+		return newPod1.UID != origUID
+	}, time.Second, 100*time.Millisecond, "Pod-1 should be recreated")
+
+	requireModelPods(t, m, 3, "3 Pods should be exist again", 2*time.Second)
+}

--- a/test/integration/model_pod_update_rollout_test.go
+++ b/test/integration/model_pod_update_rollout_test.go
@@ -31,13 +31,18 @@ func TestModelPodUpdateRollout(t *testing.T) {
 	// Expect 3 Pods to be created with the new arg.
 	require.Eventually(t, func() bool {
 		podList := &corev1.PodList{}
-		require.NoError(t, testK8sClient.List(testCtx, podList, client.InNamespace(testNS), client.MatchingLabels{"model": m.Name}))
+		if !assert.NoError(t, testK8sClient.List(testCtx, podList, client.InNamespace(testNS), client.MatchingLabels{"model": m.Name})) {
+			return false
+		}
+
 		for _, pod := range podList.Items {
 			if !assert.Contains(t, pod.Spec.Containers[0].Args, newArg, "Pod should have the new arg") {
 				return false
 			}
 		}
-		require.Equal(t, 3, len(podList.Items), "Exactly 3 Pods should exist")
+
+		assert.Equal(t, 3, len(podList.Items), "Exactly 3 Pods should exist")
+
 		return true
 	}, time.Second, 100*time.Millisecond, "Exactly 3 Pods should exist (with the new arg)")
 }

--- a/test/integration/model_pod_update_rollout_test.go
+++ b/test/integration/model_pod_update_rollout_test.go
@@ -1,0 +1,43 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestModelPodUpdateRollout tests that an update to a Model object triggers the recreation
+// of the corresponding Pods.
+func TestModelPodUpdateRollout(t *testing.T) {
+	// Create a Model object.
+	m := modelForTest(t)
+	m.Spec.MinReplicas = 3
+	m.Spec.MaxReplicas = ptr.To[int32](3)
+
+	require.NoError(t, testK8sClient.Create(testCtx, m))
+
+	// Expect 3 Pods to be created.
+	requireModelPods(t, m, 3, "3 Pods should be created", 2*time.Second)
+
+	// Update the Model object.
+	const newArg = "--my-new-arg-added-in-testcase"
+	updateModel(t, m, func() { m.Spec.Args = []string{newArg} }, "Adding a new arg to the Model")
+
+	// Expect 3 Pods to be created with the new arg.
+	require.Eventually(t, func() bool {
+		podList := &corev1.PodList{}
+		require.NoError(t, testK8sClient.List(testCtx, podList, client.InNamespace(testNS), client.MatchingLabels{"model": m.Name}))
+		for _, pod := range podList.Items {
+			if !assert.Contains(t, pod.Spec.Containers[0].Args, newArg, "Pod should have the new arg") {
+				return false
+			}
+		}
+		require.Equal(t, 3, len(podList.Items), "Exactly 3 Pods should exist")
+		return true
+	}, time.Second, 100*time.Millisecond, "Exactly 3 Pods should exist (with the new arg)")
+}


### PR DESCRIPTION
Automate the recreation of model Pods when their expected spec's change.

Currently implemented as "delete-all-pods", followed by "create-all-pods".

Fixes #219 
Fixes #236 