### PR TITLE
Update README.md to not rely on models chart

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,22 +61,21 @@ Install KubeAI and wait for all components to be ready (may take a minute).
 helm install kubeai kubeai/kubeai --wait --timeout 10m
 ```
 
-Install some predefined models.
+Install Gemma 2B using CPU and Ollama:
 
 ```bash
-cat <<EOF > kubeai-models.yaml
-catalog:
-  gemma2-2b-cpu:
-    enabled: true
-    minReplicas: 1
-  qwen2-500m-cpu:
-    enabled: true
-  nomic-embed-text-cpu:
-    enabled: true
+kubectl apply -f - <<EOF
+apiVersion: kubeai.org/v1
+kind: Model
+metadata:
+  name: gemma2-2b-cpu
+spec:
+  features: [TextGeneration]
+  url: ollama://gemma2:2b
+  engine: OLlama
+  resourceProfile: cpu:2
+  minReplicas: 1
 EOF
-
-helm install kubeai-models kubeai/models \
-    -f ./kubeai-models.yaml
 ```
 
 Before progressing to the next steps, start a watch on Pods in a standalone terminal to see how KubeAI deploys models. 
@@ -98,6 +97,22 @@ kubectl port-forward svc/openwebui 8000:80
 Now open your browser to [localhost:8000](http://localhost:8000) and select the Gemma model to start chatting with.
 
 #### Scale up Qwen2 from Zero
+
+Deploy Qwen2 with minScale set to 0:
+```
+kubectl apply -f - <<EOF
+apiVersion: kubeai.org/v1
+kind: Model
+metadata:
+  name: qwen2-500m-cpu
+spec:
+  features: [TextGeneration]
+  url: ollama://qwen2:0.5b
+  engine: OLlama
+  resourceProfile: cpu:1
+  minReplicas: 0
+EOF
+```
 
 If you go back to the browser and start a chat with Qwen2, you will notice that it will take a while to respond at first. This is because we set `minReplicas: 0` for this model and KubeAI needs to spin up a new Pod (you can verify with `kubectl get models -oyaml qwen2-500m-cpu`).
 


### PR DESCRIPTION
The models chart isn't being released correctly. We can switch back to using models chart once the issue is fixed.