### PR TITLE
fix #232 secret token empty validation error

### DIFF
--- a/charts/kubeai/templates/secret.yaml
+++ b/charts/kubeai/templates/secret.yaml
@@ -1,4 +1,6 @@
-{{- if .Values.secrets.huggingface.create -}}
+# Only create the secret if the token is not empty.
+# See: https://github.com/substratusai/kubeai/issues/232
+{{- if and .Values.secrets.huggingface.create (not (empty .Values.secrets.huggingface.token)) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/internal/modelcontroller/model_controller.go
+++ b/internal/modelcontroller/model_controller.go
@@ -225,7 +225,8 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, profile ModelConfig
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: r.HuggingfaceSecretName,
 					},
-					Key: "token",
+					Key:      "token",
+					Optional: ptr.To(true),
 				},
 			},
 		},


### PR DESCRIPTION
Some users have reported validation issues with a secret that has an empty string as value.

This isn't reproducible on Kind and latest versions. So this fix hasn't been validated.