### PR TITLE
Initial TPU support

### DIFF
--- a/charts/kubeai/values-gke.yaml
+++ b/charts/kubeai/values-gke.yaml
@@ -7,3 +7,24 @@ resourceProfiles:
     nodeSelector:
       cloud.google.com/gke-accelerator: "nvidia-h100-80gb"
       cloud.google.com/gke-spot: "true"
+  google-tpu-v5e-1x1:
+    imageName: google-tpu
+    limits:
+      google.com/tpu: 1
+    nodeSelector:
+      cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+      cloud.google.com/gke-tpu-topology: "1x1"
+  google-tpu-v5e-2x2:
+    imageName: google-tpu
+    limits:
+      google.com/tpu: 1
+    nodeSelector:
+      cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+      cloud.google.com/gke-tpu-topology: "2x2"
+  google-tpu-v5e-2x4:
+    imageName: google-tpu
+    limits:
+      google.com/tpu: 1
+    nodeSelector:
+      cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+      cloud.google.com/gke-tpu-topology: "2x4"

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -18,7 +18,7 @@ modelServers:
       # The "default" image should always be specified.
       # "default" is used when no imageName is specified or if a specific image is not found.
       default: "vllm/vllm-openai:v0.6.1.post2"
-      cpu: "substratusai/vllm:v0.5.5-cpu"
+      cpu: "ghcr.io/substratusai/vllm:v0.6.1-cpu"
       nvidia-gpu: "vllm/vllm-openai:v0.6.1.post2"
       google-tpu: "ghcr.io/substratusai/vllm:v0.6.1-tpu"
   OLlama:
@@ -52,7 +52,13 @@ resourceProfiles:
     imageName: "cpu"
     requests:
       cpu: 1
+      # TODO: Consider making this a ratio that is more common on cloud machines
+      # such as 1:4 CPU:Mem. NOTE: This might need to be adjusted for local clusters.
       memory: "2Gi"
+      # TODO: Consider adding eph storage requests/limits.
+      # Perhaps this is just needed for GKE Autopilot which defaults
+      # to 1Gi for CPU-only.
+      # ephemeral-storage: "2Gi"
   nvidia-gpu-l4:
     imageName: "nvidia-gpu"
     limits:

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -20,8 +20,7 @@ modelServers:
       default: "vllm/vllm-openai:v0.6.1.post2"
       cpu: "substratusai/vllm:v0.5.5-cpu"
       nvidia-gpu: "vllm/vllm-openai:v0.6.1.post2"
-      # TODO publish tpu image.
-      google-tpu: "substratusai/vllm-openai-tpu:v0.5.5"
+      google-tpu: "ghcr.io/substratusai/vllm:v0.6.1-tpu"
   OLlama:
     images:
       default: "ollama/ollama:latest"

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -18,9 +18,9 @@ modelServers:
       # The "default" image should always be specified.
       # "default" is used when no imageName is specified or if a specific image is not found.
       default: "vllm/vllm-openai:v0.6.1.post2"
-      cpu: "ghcr.io/substratusai/vllm:v0.6.1-cpu"
+      cpu: "substratusai/vllm:v0.6.1-cpu"
       nvidia-gpu: "vllm/vllm-openai:v0.6.1.post2"
-      google-tpu: "ghcr.io/substratusai/vllm:v0.6.1-tpu"
+      google-tpu: "substratusai/vllm:v0.6.1-tpu"
   OLlama:
     images:
       default: "ollama/ollama:latest"

--- a/charts/models/values.yaml
+++ b/charts/models/values.yaml
@@ -21,6 +21,36 @@ catalog:
     url: "ollama://gemma2:2b"
     engine: OLlama
     resourceProfile: cpu:2
+  gemma-2b-it-tpu:
+    enabled: false
+    features: ["TextGeneration"]
+    owner: google
+    url: "hf://google/gemma-2b-it"
+    engine: VLLM
+    resourceProfile: google-tpu-v5e-1x1:1
+    args:
+    - --disable-log-requests
+  #gemma2-9b-it-fp8-tpu:
+  #  enabled: false
+  #  features: ["TextGeneration"]
+  #  owner: neuralmagic
+  #  # ValueError: fp8 quantization is currently not supported in TPU Backend.
+  #  #url: "hf://neuralmagic/gemma-2-9b-it-FP8"
+  #  engine: VLLM
+  #  resourceProfile: google-tpu-v5e-1x1:1
+  #  args:
+  #  - --disable-log-requests
+  #gemma2-9b-it-int8-tpu:
+  #  enabled: false
+  #  features: ["TextGeneration"]
+  #  owner: neuralmagic
+  #  # ValueError: compressed-tensors quantization is currently not supported in TPU Backend.
+  #  #url: "hf://neuralmagic/gemma-2-9b-it-quantized.w8a8"
+  #  #url: "hf://neuralmagic/gemma-2-9b-it-quantized.w8a16"
+  #  engine: VLLM
+  #  resourceProfile: google-tpu-v5e-1x1:1
+  #  args:
+  #  - --disable-log-requests
   # Llama #
   llama-3.1-8b-instruct-cpu:
     enabled: false
@@ -34,6 +64,38 @@ catalog:
     args:
     - --max-model-len=32768
     - --max-num-batched-token=32768
+  llama-3.1-8b-instruct-tpu:
+    enabled: false
+    features: ["TextGeneration"]
+    owner: meta-llama
+    url: "hf://meta-llama/Meta-Llama-3.1-8B-Instruct"
+    engine: VLLM
+    resourceProfile: google-tpu-v5e-2x2:4
+    args:
+    - --disable-log-requests
+    - --swap-space=8
+    - --tensor-parallel-size=4
+    - --num-scheduler-steps=4
+    - --max-model-len=8192
+    # Set backend to ray b/c using "--distributed-executor-backend=mp" (or letting it default)
+    # results in the following error:
+    #
+    # Traceback (most recent call last):
+    #   File "/usr/local/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
+    #     self.run()
+    #   File "/usr/local/lib/python3.10/multiprocessing/process.py", line 108, in run
+    #     self._target(*self._args, **self._kwargs)
+    #   File "/workspace/vllm/vllm/entrypoints/openai/rpc/server.py", line 236, in run_rpc_server
+    #     server = AsyncEngineRPCServer(async_engine_args, usage_context, rpc_path)
+    #   File "/workspace/vllm/vllm/entrypoints/openai/rpc/server.py", line 34, in __init__
+    #     self.engine = AsyncLLMEngine.from_engine_args(
+    #   File "/workspace/vllm/vllm/engine/async_llm_engine.py", line 732, in from_engine_args
+    #     executor_class = cls._get_executor_cls(engine_config)
+    #   File "/workspace/vllm/vllm/engine/async_llm_engine.py", line 675, in _get_executor_cls
+    #     assert distributed_executor_backend is None
+    # AssertionError
+    #
+    - --distributed-executor-backend=ray
   llama-3.1-8b-instruct-fp8-l4:
     enabled: false
     features: ["TextGeneration"]

--- a/charts/models/values.yaml
+++ b/charts/models/values.yaml
@@ -10,6 +10,7 @@ catalog:
     owner: intfloat
     url: "hf://intfloat/e5-mistral-7b-instruct"
     engine: VLLM
+    # TODO: Adjust - the memory associated with this request is too low.
     resourceProfile: cpu:1
     args:
     - --gpu-memory-utilization=0.9
@@ -30,27 +31,27 @@ catalog:
     resourceProfile: google-tpu-v5e-1x1:1
     args:
     - --disable-log-requests
-  #gemma2-9b-it-fp8-tpu:
-  #  enabled: false
-  #  features: ["TextGeneration"]
-  #  owner: neuralmagic
-  #  # ValueError: fp8 quantization is currently not supported in TPU Backend.
-  #  #url: "hf://neuralmagic/gemma-2-9b-it-FP8"
-  #  engine: VLLM
-  #  resourceProfile: google-tpu-v5e-1x1:1
-  #  args:
-  #  - --disable-log-requests
-  #gemma2-9b-it-int8-tpu:
-  #  enabled: false
-  #  features: ["TextGeneration"]
-  #  owner: neuralmagic
-  #  # ValueError: compressed-tensors quantization is currently not supported in TPU Backend.
-  #  #url: "hf://neuralmagic/gemma-2-9b-it-quantized.w8a8"
-  #  #url: "hf://neuralmagic/gemma-2-9b-it-quantized.w8a16"
-  #  engine: VLLM
-  #  resourceProfile: google-tpu-v5e-1x1:1
-  #  args:
-  #  - --disable-log-requests
+  # gemma2-9b-it-fp8-tpu:
+  #   enabled: false
+  #   features: ["TextGeneration"]
+  #   owner: neuralmagic
+  #   # vLLM logs: "ValueError: fp8 quantization is currently not supported in TPU Backend."
+  #   #url: "hf://neuralmagic/gemma-2-9b-it-FP8"
+  #   engine: VLLM
+  #   resourceProfile: google-tpu-v5e-1x1:1
+  #   args:
+  #   - --disable-log-requests
+  # gemma2-9b-it-int8-tpu:
+  #   enabled: false
+  #   features: ["TextGeneration"]
+  #   owner: neuralmagic
+  #   # vLLM logs: "ValueError: compressed-tensors quantization is currently not supported in TPU Backend."
+  #   #url: "hf://neuralmagic/gemma-2-9b-it-quantized.w8a8"
+  #   #url: "hf://neuralmagic/gemma-2-9b-it-quantized.w8a16"
+  #   engine: VLLM
+  #   resourceProfile: google-tpu-v5e-1x1:1
+  #   args:
+  #   - --disable-log-requests
   # Llama #
   llama-3.1-8b-instruct-cpu:
     enabled: false
@@ -143,6 +144,7 @@ catalog:
     owner: facebook
     url: "hf://facebook/opt-125m"
     engine: VLLM
+    # TODO: Adjust - the memory associated with this request is too low.
     resourceProfile: cpu:1
   opt-125m-l4:
     enabled: false

--- a/hack/apply-model.sh
+++ b/hack/apply-model.sh
@@ -1,0 +1,2 @@
+model='opt-125m-cpu'
+helm template ./charts/models --set "catalog.$model.enabled=true" --set "catalog.$model.minReplicas=1" | kubectl apply -f -


### PR DESCRIPTION
* Add v5e resource profiles for GKE
* Add models: `gemma-2b-it-tpu`, `llama-3.1-8b-instruct-tpu`
* Remove outdated vLLM metrics workaround (conflicted with using flags needed to support multiple TPUs)
* Update vLLM cpu image to include metrics fix from vLLM