### PR TITLE
Adding Build WF timeout to address stuck WF's

### DIFF
--- a/.github/workflows/build-push-kubeai.yml
+++ b/.github/workflows/build-push-kubeai.yml
@@ -17,8 +17,8 @@ env:
 jobs:
   kubeai:
     runs-on: ubuntu-latest
-    # Timeout to address Github actions stuck scenarios 
-    timeout-minutes: 10
+    # Timeout to address Github actions stuck scenarios.
+    timeout-minutes: 60
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read

--- a/.github/workflows/build-push-kubeai.yml
+++ b/.github/workflows/build-push-kubeai.yml
@@ -17,6 +17,8 @@ env:
 jobs:
   kubeai:
     runs-on: ubuntu-latest
+    # Timeout to address Github actions stuck scenarios 
+    timeout-minutes: 10
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read


### PR DESCRIPTION
This change will limit the WF action timeout to address GitHub hosted action communication issue. 