### PR TITLE
Add Lambda's tutorial and video to the README's table of adopters

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -121,6 +121,7 @@ List of known adopters:
 | ---- | ----------- | ---- |
 | Telescope | Telescope uses KubeAI for multi-region large scale batch LLM inference. | [trytelescope.ai](https://trytelescope.ai) |
 | Google Cloud Distributed Edge | KubeAI is included as a reference architecture for inferencing at the edge. | [LinkedIn](https://www.linkedin.com/posts/mikeensor_gcp-solutions-public-retail-edge-available-cluster-traits-activity-7237515920259104769-vBs9?utm_source=share&utm_medium=member_desktop), [GitLab](https://gitlab.com/gcp-solutions-public/retail-edge/available-cluster-traits/kubeai-cluster-trait) |
+| Lambda | You can try KubeAI on the Lambda AI Developer Cloud. See Lambda's [tutorial](https://docs.lambdalabs.com/education/large-language-models/kubeai-hermes-3/) and [video](https://youtu.be/HEtPO2Wuiac). | [Lambda](https://lambdalabs.com/) |
 
 If you are using KubeAI and would like to be listed as an adopter, please make a PR.
 


### PR DESCRIPTION
This pull requests adds [Lambda](https://lambdalabs.com/) to the table of adopters in the README and links to Lambda's KubeAI [tutorial](https://docs.lambdalabs.com/education/large-language-models/kubeai-hermes-3/) and [YouTube video](https://youtu.be/HEtPO2Wuiac).