### PR TITLE
Add initial dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,53 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "01:00"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "01:00"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "01:00"
+    groups:
+      actions-all:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: daily
+      time: "01:00"
+
+  - package-ecosystem: "docker"
+    directory: "/components/model-loader"
+    schedule:
+      interval: daily
+      time: "01:00"
+
+  - package-ecosystem: "docker"
+    directory: "/examples/ollama-builtin"
+    schedule:
+      interval: daily
+      time: "01:00"
+
+  - package-ecosystem: "gomod"
+    directory: "/examples/private-deep-chat"
+    schedule:
+      interval: daily
+      time: "01:00"
+
+  - package-ecosystem: "docker"
+    directory: "/examples/private-deep-chat"
+    schedule:
+      interval: daily
+      time: "01:00"


### PR DESCRIPTION
# Add Dependabot

Nice support bot that helps keeping dependencies up to date and act fast on security patches.
To test the config, I did a [run on my fork](https://github.com/alpe/lingo/actions/workflows/dependabot/dependabot-updates).

More about the config in the [Dependabot doc](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

❗ Note: Merging the config does not enable the bot. Visit the project "Settings>> Code security" and enable all `Dependabot` features.