### PR TITLE
Fix formatting for docs

### DIFF
--- a/docs/installation/any.md
+++ b/docs/installation/any.md
@@ -68,6 +68,7 @@ helm upgrade --install kubeai kubeai/kubeai \
 ## Deploying models
 
 Take a look at the following how-to guides to deploy models:
+
 * [Configure Text Generation Models](../how-to/configure-text-generation-models.md)
 * [Configure Embedding Models](../how-to/configure-embedding-models.md)
 * [Configure Speech to Text Models](../how-to/configure-speech-to-text.md)

--- a/docs/installation/eks.md
+++ b/docs/installation/eks.md
@@ -148,6 +148,7 @@ helm upgrade --install kubeai kubeai/kubeai \
 ## 4. Deploying models
 
 Take a look at the following how-to guides to deploy models:
+
 * [Configure Text Generation Models](../how-to/configure-text-generation-models.md)
 * [Configure Embedding Models](../how-to/configure-embedding-models.md)
 * [Configure Speech to Text Models](../how-to/configure-speech-to-text.md)

--- a/docs/installation/gke.md
+++ b/docs/installation/gke.md
@@ -65,6 +65,7 @@ helm upgrade --install kubeai kubeai/kubeai \
 ## 4. Deploying models
 
 Take a look at the following how-to guides to deploy models:
+
 * [Configure Text Generation Models](../how-to/configure-text-generation-models.md)
 * [Configure Embedding Models](../how-to/configure-embedding-models.md)
 * [Configure Speech to Text Models](../how-to/configure-speech-to-text.md)


### PR DESCRIPTION
Currently looks like this:

![image](https://github.com/user-attachments/assets/b2a2b140-7928-4ab4-98bd-f176946d7b61)
