### PR TITLE
vLLM: Add support for loading models from PVC

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,12 @@ jobs:
     #needs: unit-and-integration # No use in running e2e tests if integration tests fail.
     strategy:
       matrix:
-        testcase: ["quickstart", "openai-python-client", "autoscaler-restart", "cache-shared-filesystem"]
+        testcase:
+        - "quickstart"
+        - "openai-python-client"
+        - "autoscaler-restart"
+        - "cache-shared-filesystem"
+        - "engine-vllm-pvc"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,10 @@ test-e2e-autoscaler-restart: skaffold
 test-e2e-cache-shared-filesystem: skaffold
 	./test/e2e/run.sh cache-shared-filesystem --profile e2e-test-default
 
+.PHONY: test-e2e-engine-vllm-pvc
+test-e2e-engine-vllm-pvc: skaffold
+	./test/e2e/run.sh engine-vllm-pvc --profile e2e-test-default
+
 .PHONY: test-e2e-engine
 test-e2e-engine: skaffold
 	CACHE_PROFILE=$(CACHE_PROFILE) ./test/e2e/run.sh engine-$(ENGINE) --profile e2e-test-default

--- a/api/v1/model_types.go
+++ b/api/v1/model_types.go
@@ -21,11 +21,10 @@ import (
 )
 
 // ModelSpec defines the desired state of Model.
-// +kubebuilder:validation:XValidation:rule="!has(self.cacheProfile) || self.url.startsWith(\"hf://\") || self.url.startsWith(\"pvc://\") || self.url.startsWith(\"s3://\") || self.url.startsWith(\"gs://\") || self.url.startsWith(\"oss://\")", message="cacheProfile is only supported with urls of format \"hf://...\", \"pvc://...\", \"s3://...\", \"gs://...\", or \"oss://...\" at the moment."
+// +kubebuilder:validation:XValidation:rule="!has(self.cacheProfile) || self.url.startsWith(\"hf://\") || self.url.startsWith(\"s3://\") || self.url.startsWith(\"gs://\") || self.url.startsWith(\"oss://\")", message="cacheProfile is only supported with urls of format \"hf://...\", \"s3://...\", \"gs://...\", or \"oss://...\" at the moment."
 // +kubebuilder:validation:XValidation:rule="!self.url.startsWith(\"s3://\") || has(self.cacheProfile)", message="urls of format \"s3://...\" only supported when using a cacheProfile"
 // +kubebuilder:validation:XValidation:rule="!self.url.startsWith(\"gs://\") || has(self.cacheProfile)", message="urls of format \"gs://...\" only supported when using a cacheProfile"
 // +kubebuilder:validation:XValidation:rule="!self.url.startsWith(\"oss://\") || has(self.cacheProfile)", message="urls of format \"oss://...\" only supported when using a cacheProfile"
-// +kubebuilder:validation:XValidation:rule="self.url.startsWith(\"pvc://\") || has(self.cacheProfile)", message="urls of format \"pvc://...\" do not support cacheProfile. Remove cacheProfile or use a different url."
 // +kubebuilder:validation:XValidation:rule="!has(self.maxReplicas) || self.minReplicas <= self.maxReplicas", message="minReplicas should be less than or equal to maxReplicas."
 // +kubebuilder:validation:XValidation:rule="!has(self.adapters) || self.engine == \"VLLM\"", message="adapters only supported with VLLM engine."
 type ModelSpec struct {

--- a/api/v1/model_types.go
+++ b/api/v1/model_types.go
@@ -21,10 +21,11 @@ import (
 )
 
 // ModelSpec defines the desired state of Model.
-// +kubebuilder:validation:XValidation:rule="!has(self.cacheProfile) || self.url.startsWith(\"hf://\") || self.url.startsWith(\"s3://\") || self.url.startsWith(\"gs://\") || self.url.startsWith(\"oss://\")", message="cacheProfile is only supported with urls of format \"hf://...\", \"s3://...\", \"gs://...\", or \"oss://...\" at the moment."
+// +kubebuilder:validation:XValidation:rule="!has(self.cacheProfile) || self.url.startsWith(\"hf://\") || self.url.startsWith(\"pvc://\") || self.url.startsWith(\"s3://\") || self.url.startsWith(\"gs://\") || self.url.startsWith(\"oss://\")", message="cacheProfile is only supported with urls of format \"hf://...\", \"pvc://...\", \"s3://...\", \"gs://...\", or \"oss://...\" at the moment."
 // +kubebuilder:validation:XValidation:rule="!self.url.startsWith(\"s3://\") || has(self.cacheProfile)", message="urls of format \"s3://...\" only supported when using a cacheProfile"
 // +kubebuilder:validation:XValidation:rule="!self.url.startsWith(\"gs://\") || has(self.cacheProfile)", message="urls of format \"gs://...\" only supported when using a cacheProfile"
 // +kubebuilder:validation:XValidation:rule="!self.url.startsWith(\"oss://\") || has(self.cacheProfile)", message="urls of format \"oss://...\" only supported when using a cacheProfile"
+// +kubebuilder:validation:XValidation:rule="self.url.startsWith(\"pvc://\") || has(self.cacheProfile)", message="urls of format \"pvc://...\" do not support cacheProfile. Remove cacheProfile or use a different url."
 // +kubebuilder:validation:XValidation:rule="!has(self.maxReplicas) || self.minReplicas <= self.maxReplicas", message="minReplicas should be less than or equal to maxReplicas."
 // +kubebuilder:validation:XValidation:rule="!has(self.adapters) || self.engine == \"VLLM\"", message="adapters only supported with VLLM engine."
 type ModelSpec struct {
@@ -34,6 +35,8 @@ type ModelSpec struct {
 	// For VLLM, FasterWhisper, Infinity engines:
 	//
 	// "hf://<repo>/<model>"
+	// "pvc://<pvcName>"
+	// "pvc://<pvcName>/<pvcSubpath>"
 	// "gs://<bucket>/<path>" (only with cacheProfile)
 	// "oss://<bucket>/<path>" (only with cacheProfile)
 	// "s3://<bucket>/<path>" (only with cacheProfile)

--- a/api/v1/model_types.go
+++ b/api/v1/model_types.go
@@ -46,7 +46,7 @@ type ModelSpec struct {
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="url is immutable."
-	// +kubebuilder:validation:XValidation:rule="self.startsWith(\"hf://\") || self.startsWith(\"ollama://\") || self.startsWith(\"s3://\") || self.startsWith(\"gs://\") || self.startsWith(\"oss://\")", message="url must start with \"hf://\", \"ollama://\", \"s3://\", \"gs://\", or \"oss://\" and not be empty."
+	// +kubebuilder:validation:XValidation:rule="self.startsWith(\"hf://\") || self.startsWith(\"pvc://\") || self.startsWith(\"ollama://\") || self.startsWith(\"s3://\") || self.startsWith(\"gs://\") || self.startsWith(\"oss://\")", message="url must start with \"hf://\", \"pvc://\", \"ollama://\", \"s3://\", \"gs://\", or \"oss://\" and not be empty."
 	URL string `json:"url"`
 
 	Adapters []Adapter `json:"adapters,omitempty"`

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -193,19 +193,15 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: cacheProfile is only supported with urls of format "hf://...",
-                "pvc://...", "s3://...", "gs://...", or "oss://..." at the moment.
-              rule: '!has(self.cacheProfile) || self.url.startsWith("hf://") || self.url.startsWith("pvc://")
-                || self.url.startsWith("s3://") || self.url.startsWith("gs://") ||
-                self.url.startsWith("oss://")'
+                "s3://...", "gs://...", or "oss://..." at the moment.
+              rule: '!has(self.cacheProfile) || self.url.startsWith("hf://") || self.url.startsWith("s3://")
+                || self.url.startsWith("gs://") || self.url.startsWith("oss://")'
             - message: urls of format "s3://..." only supported when using a cacheProfile
               rule: '!self.url.startsWith("s3://") || has(self.cacheProfile)'
             - message: urls of format "gs://..." only supported when using a cacheProfile
               rule: '!self.url.startsWith("gs://") || has(self.cacheProfile)'
             - message: urls of format "oss://..." only supported when using a cacheProfile
               rule: '!self.url.startsWith("oss://") || has(self.cacheProfile)'
-            - message: urls of format "pvc://..." do not support cacheProfile. Remove
-                cacheProfile or use a different url.
-              rule: self.url.startsWith("pvc://") || has(self.cacheProfile)
             - message: minReplicas should be less than or equal to maxReplicas.
               rule: '!has(self.maxReplicas) || self.minReplicas <= self.maxReplicas'
             - message: adapters only supported with VLLM engine.

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -165,6 +165,8 @@ spec:
 
 
                   "hf://<repo>/<model>"
+                  "pvc://<pvcName>"
+                  "pvc://<pvcName>/<pvcSubpath>"
                   "gs://<bucket>/<path>" (only with cacheProfile)
                   "oss://<bucket>/<path>" (only with cacheProfile)
                   "s3://<bucket>/<path>" (only with cacheProfile)
@@ -191,15 +193,19 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: cacheProfile is only supported with urls of format "hf://...",
-                "s3://...", "gs://...", or "oss://..." at the moment.
-              rule: '!has(self.cacheProfile) || self.url.startsWith("hf://") || self.url.startsWith("s3://")
-                || self.url.startsWith("gs://") || self.url.startsWith("oss://")'
+                "pvc://...", "s3://...", "gs://...", or "oss://..." at the moment.
+              rule: '!has(self.cacheProfile) || self.url.startsWith("hf://") || self.url.startsWith("pvc://")
+                || self.url.startsWith("s3://") || self.url.startsWith("gs://") ||
+                self.url.startsWith("oss://")'
             - message: urls of format "s3://..." only supported when using a cacheProfile
               rule: '!self.url.startsWith("s3://") || has(self.cacheProfile)'
             - message: urls of format "gs://..." only supported when using a cacheProfile
               rule: '!self.url.startsWith("gs://") || has(self.cacheProfile)'
             - message: urls of format "oss://..." only supported when using a cacheProfile
               rule: '!self.url.startsWith("oss://") || has(self.cacheProfile)'
+            - message: urls of format "pvc://..." do not support cacheProfile. Remove
+                cacheProfile or use a different url.
+              rule: self.url.startsWith("pvc://") || has(self.cacheProfile)
             - message: minReplicas should be less than or equal to maxReplicas.
               rule: '!has(self.maxReplicas) || self.minReplicas <= self.maxReplicas'
             - message: adapters only supported with VLLM engine.

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -180,10 +180,10 @@ spec:
                 x-kubernetes-validations:
                 - message: url is immutable.
                   rule: self == oldSelf
-                - message: url must start with "hf://", "ollama://", "s3://", "gs://",
-                    or "oss://" and not be empty.
-                  rule: self.startsWith("hf://") || self.startsWith("ollama://") ||
-                    self.startsWith("s3://") || self.startsWith("gs://") || self.startsWith("oss://")
+                - message: url must start with "hf://", "pvc://", "ollama://", "s3://",
+                    "gs://", or "oss://" and not be empty.
+                  rule: self.startsWith("hf://") || self.startsWith("pvc://") || self.startsWith("ollama://")
+                    || self.startsWith("s3://") || self.startsWith("gs://") || self.startsWith("oss://")
             required:
             - engine
             - features

--- a/docs/how-to/install-models.md
+++ b/docs/how-to/install-models.md
@@ -94,6 +94,22 @@ spec:
   resourceProfile: nvidia-gpu-l4:1
 ```
 
+## Load Models from PVC
+
+You can store your models in a Persistent Volume Claim (PVC) and load them into KubeAI for serving. This guide will show you how to load models from a PVC.
+
+Currenly only vLLM supports loading models from PVCs.
+
+The following formats are supported to load models from a PVC:
+
+- `url: pvc://$PVC_NAME` - Loads the model from the PVC named `$PVC_NAME`.
+- `url: pvc://$PVC_NAME/$PATH` - Loads the model from the PVC named `$PVC_NAME` and mounts the subpath `$PATH` within the PVC.
+
+You need to make sure the model is preloaded into the PVC before you can use it in KubeAI.
+
+The Access Mode of the PVC should be `ReadOnlyMany` or `ReadWriteMany`, because otherwise
+KubeAI won't be able to spin up more than 1 replica of the model.
+
 ## Programmatically installing models
 
 See the [examples](https://github.com/substratusai/kubeai/tree/main/examples/k8s-api-clients).

--- a/docs/reference/kubernetes-api.md
+++ b/docs/reference/kubernetes-api.md
@@ -76,7 +76,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `url` _string_ | URL of the model to be served.<br />Currently the following formats are supported:<br /><br />For VLLM, FasterWhisper, Infinity engines:<br /><br />"hf://<repo>/<model>"<br />"gs://<bucket>/<path>" (only with cacheProfile)<br />"oss://<bucket>/<path>" (only with cacheProfile)<br />"s3://<bucket>/<path>" (only with cacheProfile)<br /><br />For OLlama engine:<br /><br />"ollama://<model>" |  | Required: \{\} <br /> |
+| `url` _string_ | URL of the model to be served.<br />Currently the following formats are supported:<br /><br />For VLLM, FasterWhisper, Infinity engines:<br /><br />"hf://<repo>/<model>"<br />"pvc://<pvcName>"<br />"pvc://<pvcName>/<pvcSubpath>"<br />"gs://<bucket>/<path>" (only with cacheProfile)<br />"oss://<bucket>/<path>" (only with cacheProfile)<br />"s3://<bucket>/<path>" (only with cacheProfile)<br /><br />For OLlama engine:<br /><br />"ollama://<model>" |  | Required: \{\} <br /> |
 | `adapters` _[Adapter](#adapter) array_ |  |  |  |
 | `features` _[ModelFeature](#modelfeature) array_ | Features that the model supports.<br />Dictates the APIs that are available for the model. |  | Enum: [TextGeneration TextEmbedding SpeechToText] <br /> |
 | `engine` _string_ | Engine to be used for the server process. |  | Enum: [OLlama VLLM FasterWhisper Infinity] <br />Required: \{\} <br /> |

--- a/internal/modelcontroller/cache.go
+++ b/internal/modelcontroller/cache.go
@@ -351,7 +351,7 @@ func (r *ModelReconciler) loadCacheJobForModel(m *kubeaiv1.Model, c ModelConfig)
 		m.Spec.URL,
 		modelCacheDir(m),
 	}
-	c.Source.modelAuthCredentials.applyToPodSpec(&job.Spec.Template.Spec, 0)
+	c.Source.modelSourcePodAdditions.applyToPodSpec(&job.Spec.Template.Spec, 0)
 
 	return job
 }

--- a/internal/modelcontroller/engine_fasterwhisper.go
+++ b/internal/modelcontroller/engine_fasterwhisper.go
@@ -137,7 +137,7 @@ func (r *ModelReconciler) fasterWhisperPodForModel(m *kubeaiv1.Model, c ModelCon
 	}
 
 	patchServerCacheVolumes(&pod.Spec, m, c)
-	c.Source.modelAuthCredentials.applyToPodSpec(&pod.Spec, 0)
+	c.Source.modelSourcePodAdditions.applyToPodSpec(&pod.Spec, 0)
 
 	return pod
 }

--- a/internal/modelcontroller/engine_infinity.go
+++ b/internal/modelcontroller/engine_infinity.go
@@ -157,7 +157,7 @@ func (r *ModelReconciler) infinityPodForModel(m *kubeaiv1.Model, c ModelConfig) 
 	}
 
 	patchServerCacheVolumes(&pod.Spec, m, c)
-	c.Source.modelAuthCredentials.applyToPodSpec(&pod.Spec, 0)
+	c.Source.modelSourcePodAdditions.applyToPodSpec(&pod.Spec, 0)
 
 	return pod
 }

--- a/internal/modelcontroller/engine_ollama.go
+++ b/internal/modelcontroller/engine_ollama.go
@@ -169,7 +169,7 @@ func (r *ModelReconciler) oLlamaPodForModel(m *kubeaiv1.Model, c ModelConfig) *c
 	}
 
 	patchServerCacheVolumes(&pod.Spec, m, c)
-	c.Source.modelAuthCredentials.applyToPodSpec(&pod.Spec, 0)
+	c.Source.modelSourcePodAdditions.applyToPodSpec(&pod.Spec, 0)
 
 	return pod
 

--- a/internal/modelcontroller/engine_vllm.go
+++ b/internal/modelcontroller/engine_vllm.go
@@ -145,7 +145,7 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 
 	r.patchServerAdapterLoader(&pod.Spec, m, r.ModelLoaders.Image)
 	patchServerCacheVolumes(&pod.Spec, m, c)
-	c.Source.modelAuthCredentials.applyToPodSpec(&pod.Spec, 0)
+	c.Source.modelSourcePodAdditions.applyToPodSpec(&pod.Spec, 0)
 
 	return pod
 }

--- a/internal/modelcontroller/engine_vllm.go
+++ b/internal/modelcontroller/engine_vllm.go
@@ -21,6 +21,10 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 	if m.Spec.CacheProfile != "" {
 		vllmModelFlag = modelCacheDir(m)
 	}
+	// TODO we should throw an error if cache profile is set AND the model is on PVC.
+	if c.Source.url.scheme == "pvc" {
+		vllmModelFlag = "/model"
+	}
 
 	args := []string{
 		"--model=" + vllmModelFlag,

--- a/internal/modelcontroller/engine_vllm.go
+++ b/internal/modelcontroller/engine_vllm.go
@@ -21,6 +21,8 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 	if m.Spec.CacheProfile != "" {
 		vllmModelFlag = modelCacheDir(m)
 	}
+	// The vllmModelFlag can be safely overridden because validation logic ensures
+	// that a model with PVC source and cacheProfile won't be admitted.
 	if c.Source.url.scheme == "pvc" {
 		vllmModelFlag = "/model"
 	}

--- a/internal/modelcontroller/engine_vllm.go
+++ b/internal/modelcontroller/engine_vllm.go
@@ -21,7 +21,6 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 	if m.Spec.CacheProfile != "" {
 		vllmModelFlag = modelCacheDir(m)
 	}
-	// TODO we should throw an error if cache profile is set AND the model is on PVC.
 	if c.Source.url.scheme == "pvc" {
 		vllmModelFlag = "/model"
 	}

--- a/internal/modelcontroller/model_source.go
+++ b/internal/modelcontroller/model_source.go
@@ -200,7 +200,6 @@ func (r *ModelReconciler) pvcPodAdditions(url modelURL) *modelSourcePodAdditions
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: url.name,
-						ReadOnly:  true,
 					},
 				},
 			},

--- a/internal/modelcontroller/model_source_test.go
+++ b/internal/modelcontroller/model_source_test.go
@@ -28,6 +28,8 @@ func Test_parseModelURL(t *testing.T) {
 			want: modelURL{
 				scheme: "a",
 				ref:    "path/b://to/model",
+				name:   "path",
+				path:   "b://to/model",
 			},
 		},
 		"valid-google-storage": {
@@ -35,6 +37,8 @@ func Test_parseModelURL(t *testing.T) {
 			want: modelURL{
 				scheme: "gs",
 				ref:    "bucket-name/path/to/model",
+				name:   "bucket-name",
+				path:   "path/to/model",
 			},
 		},
 		"valid-ollama": {
@@ -42,6 +46,8 @@ func Test_parseModelURL(t *testing.T) {
 			want: modelURL{
 				scheme: "ollama",
 				ref:    "gemma2:2b",
+				name:   "gemma2:2b",
+				path:   "",
 			},
 		},
 		"valid-huggingface": {
@@ -49,6 +55,8 @@ func Test_parseModelURL(t *testing.T) {
 			want: modelURL{
 				scheme: "hf",
 				ref:    "test-user/model-name",
+				name:   "test-user",
+				path:   "model-name",
 			},
 		},
 		"valid-pvc": {
@@ -56,6 +64,35 @@ func Test_parseModelURL(t *testing.T) {
 			want: modelURL{
 				scheme: "pvc",
 				ref:    "my-vpc/path/to/model",
+				name:   "my-vpc",
+				path:   "path/to/model",
+			},
+		},
+		"valid-pvc-no-path": {
+			input: "pvc://my-vpc",
+			want: modelURL{
+				scheme: "pvc",
+				ref:    "my-vpc",
+				name:   "my-vpc",
+				path:   "",
+			},
+		},
+		"valid-pvc-with-slash-empty": {
+			input: "pvc://my-vpc/",
+			want: modelURL{
+				scheme: "pvc",
+				ref:    "my-vpc/",
+				name:   "my-vpc",
+				path:   "",
+			},
+		},
+		"valid-pvc-with-double-slash": {
+			input: "pvc://my-vpc//",
+			want: modelURL{
+				scheme: "pvc",
+				ref:    "my-vpc//",
+				name:   "my-vpc",
+				path:   "/",
 			},
 		},
 	}
@@ -74,45 +111,4 @@ func Test_parseModelURL(t *testing.T) {
 			require.Equal(t, c.want, got)
 		})
 	}
-}
-
-func Test_parsePVCNamePath(t *testing.T) {
-	t.Parallel()
-
-	cases := map[string]struct {
-		ref     string
-		pvcName string
-		path    string
-	}{
-		"fully-specified": {
-			ref:     "my-pvc/llama",
-			pvcName: "my-pvc",
-			path:    "llama",
-		},
-		"root": {
-			ref:     "my-pvc/",
-			pvcName: "my-pvc",
-			path:    "",
-		},
-		"root-with-additional-slash": {
-			ref:     "my-pvc//",
-			pvcName: "my-pvc",
-			path:    "",
-		},
-		"no-slash-in-middle": {
-			ref:     "my-pvc",
-			pvcName: "my-pvc",
-			path:    "",
-		},
-	}
-
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			pvcName, path := parsePVCNamePath(modelURL{ref: c.ref})
-			require.Equal(t, c.pvcName, pvcName)
-			require.Equal(t, c.path, path)
-		})
-	}
-
 }

--- a/internal/modelcontroller/model_source_test.go
+++ b/internal/modelcontroller/model_source_test.go
@@ -51,6 +51,13 @@ func Test_parseModelURL(t *testing.T) {
 				ref:    "test-user/model-name",
 			},
 		},
+		"valid-pvc": {
+			input: "pvc://my-vpc/path/to/model",
+			want: modelURL{
+				scheme: "pvc",
+				ref:    "my-vpc/path/to/model",
+			},
+		},
 	}
 
 	for name, c := range cases {
@@ -67,4 +74,45 @@ func Test_parseModelURL(t *testing.T) {
 			require.Equal(t, c.want, got)
 		})
 	}
+}
+
+func Test_parsePVCNamePath(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		ref     string
+		pvcName string
+		path    string
+	}{
+		"fully-specified": {
+			ref:     "my-pvc/llama",
+			pvcName: "my-pvc",
+			path:    "llama",
+		},
+		"root": {
+			ref:     "my-pvc/",
+			pvcName: "my-pvc",
+			path:    "",
+		},
+		"root-with-additional-slash": {
+			ref:     "my-pvc//",
+			pvcName: "my-pvc",
+			path:    "",
+		},
+		"no-slash-in-middle": {
+			ref:     "my-pvc",
+			pvcName: "my-pvc",
+			path:    "",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			pvcName, path := parsePVCNamePath(modelURL{ref: c.ref})
+			require.Equal(t, c.pvcName, pvcName)
+			require.Equal(t, c.path, path)
+		})
+	}
+
 }

--- a/test/e2e/common-manifests.yaml
+++ b/test/e2e/common-manifests.yaml
@@ -3,13 +3,10 @@ kind: PersistentVolume
 metadata:
   name: kind-hostpath
 spec:
-  storageClassName: manual
   capacity:
     storage: 10Gi
   accessModes:
     - ReadWriteMany
-    - ReadOnlyMany
-    - ReadWriteOnce
   hostPath:
     path: /tmp/data
     type: DirectoryOrCreate

--- a/test/e2e/common-manifests.yaml
+++ b/test/e2e/common-manifests.yaml
@@ -3,10 +3,13 @@ kind: PersistentVolume
 metadata:
   name: kind-hostpath
 spec:
+  storageClassName: manual
   capacity:
     storage: 10Gi
   accessModes:
     - ReadWriteMany
+    - ReadOnlyMany
+    - ReadWriteOnce
   hostPath:
     path: /tmp/data
     type: DirectoryOrCreate

--- a/test/e2e/engine-vllm-pvc/pv.yaml
+++ b/test/e2e/engine-vllm-pvc/pv.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kind-model-hostpath
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadOnlyMany
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/model
+    type: DirectoryOrCreate
+  persistentVolumeReclaimPolicy: Retain

--- a/test/e2e/engine-vllm-pvc/pvc.yaml
+++ b/test/e2e/engine-vllm-pvc/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  volumeName: kind-hostpath

--- a/test/e2e/engine-vllm-pvc/pvc.yaml
+++ b/test/e2e/engine-vllm-pvc/pvc.yaml
@@ -3,8 +3,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: model-pvc
 spec:
+  storageClassName: manual
   accessModes:
-    - ReadWriteOnce
+    - ReadOnlyMany
   resources:
     requests:
       storage: 10Gi

--- a/test/e2e/engine-vllm-pvc/pvc.yaml
+++ b/test/e2e/engine-vllm-pvc/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  volumeName: kind-hostpath
+  volumeName: kind-model-hostpath

--- a/test/e2e/engine-vllm-pvc/test.sh
+++ b/test/e2e/engine-vllm-pvc/test.sh
@@ -8,6 +8,8 @@ pip install -U "huggingface_hub[cli]"
 
 PV_HOST_PATH=/tmp/data
 
+mkdir -p ${PV_HOST_PATH}
+
 huggingface-cli download facebook/opt-125m --local-dir ${PV_HOST_PATH} \
   --exclude "tf_model.h5" --exclude "flax_model.msgpack"
 

--- a/test/e2e/engine-vllm-pvc/test.sh
+++ b/test/e2e/engine-vllm-pvc/test.sh
@@ -10,7 +10,7 @@ mkdir -p ${PV_HOST_PATH}
 
 # Execute into the kind container
 kind_container=$(docker ps --filter "name=kind-control-plane" --format "{{.ID}}")
-docker exec -it $kind_container bash -c "
+docker exec -i $kind_container bash -c "
   apt-update -y && apt-get install -y python3-pip
   pip install -U "huggingface_hub[cli]"
   mkdir -p ${PV_HOST_PATH}

--- a/test/e2e/engine-vllm-pvc/test.sh
+++ b/test/e2e/engine-vllm-pvc/test.sh
@@ -12,7 +12,7 @@ mkdir -p ${PV_HOST_PATH}
 kind_container=$(docker ps --filter "name=kind-control-plane" --format "{{.ID}}")
 docker exec -i $kind_container bash -c "
   apt update -y && apt install -y python3-pip
-  pip install -U "huggingface_hub[cli]"
+  pip install -U "huggingface_hub[cli]" --break-system-packages
   mkdir -p ${PV_HOST_PATH}
   huggingface-cli download facebook/opt-125m --local-dir ${PV_HOST_PATH} \
     --exclude 'tf_model.h5' 'flax_model.msgpack'"

--- a/test/e2e/engine-vllm-pvc/test.sh
+++ b/test/e2e/engine-vllm-pvc/test.sh
@@ -11,7 +11,7 @@ mkdir -p ${PV_HOST_PATH}
 # Execute into the kind container
 kind_container=$(docker ps --filter "name=kind-control-plane" --format "{{.ID}}")
 docker exec -i $kind_container bash -c "
-  apt-update -y && apt-get install -y python3-pip
+  apt update -y && apt install -y python3-pip
   pip install -U "huggingface_hub[cli]"
   mkdir -p ${PV_HOST_PATH}
   huggingface-cli download facebook/opt-125m --local-dir ${PV_HOST_PATH} \

--- a/test/e2e/engine-vllm-pvc/test.sh
+++ b/test/e2e/engine-vllm-pvc/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+source $REPO_DIR/test/e2e/common.sh
+
+models_release="kubeai-models"
+
+pip install -U "huggingface_hub[cli]"
+
+PV_HOST_PATH=/tmp/data
+
+huggingface-cli download facebook/opt-125m --local-dir ${PV_HOST_PATH} \
+  --exclude "tf_model.h5" --exclude "flax_model.msgpack"
+
+kubectl apply -f $REPO_DIR/test/e2e/engine-vllm-pvc/pvc.yaml
+
+helm install $models_release $REPO_DIR/charts/models -f - <<EOF
+catalog:
+  opt-125m-cpu:
+    enabled: true
+    url: pvc://model-pvc
+    minReplicas: 1
+EOF
+
+sleep 5
+
+curl http://localhost:8000/openai/v1/completions \
+  --max-time 900 \
+  -H "Content-Type: application/json" \
+  -d '{"model": "opt-125m-cpu", "prompt": "Who was the first president of the United States?", "max_tokens": 40}'

--- a/test/e2e/engine-vllm-pvc/test.sh
+++ b/test/e2e/engine-vllm-pvc/test.sh
@@ -4,14 +4,18 @@ source $REPO_DIR/test/e2e/common.sh
 
 models_release="kubeai-models"
 
-pip install -U "huggingface_hub[cli]"
-
 PV_HOST_PATH=/tmp/model
 
 mkdir -p ${PV_HOST_PATH}
 
-huggingface-cli download facebook/opt-125m --local-dir ${PV_HOST_PATH} \
-  --exclude "tf_model.h5" "flax_model.msgpack"
+# Execute into the kind container
+kind_container=$(docker ps --filter "name=kind-control-plane" --format "{{.ID}}")
+docker exec -it $kind_container bash -c "
+  apt-update -y && apt-get install -y python3-pip
+  pip install -U "huggingface_hub[cli]"
+  mkdir -p ${PV_HOST_PATH}
+  huggingface-cli download facebook/opt-125m --local-dir ${PV_HOST_PATH} \
+    --exclude 'tf_model.h5' 'flax_model.msgpack'"
 
 kubectl apply -f $REPO_DIR/test/e2e/engine-vllm-pvc/pv.yaml
 kubectl apply -f $REPO_DIR/test/e2e/engine-vllm-pvc/pvc.yaml

--- a/test/e2e/engine-vllm-pvc/test.sh
+++ b/test/e2e/engine-vllm-pvc/test.sh
@@ -11,7 +11,7 @@ PV_HOST_PATH=/tmp/data
 mkdir -p ${PV_HOST_PATH}
 
 huggingface-cli download facebook/opt-125m --local-dir ${PV_HOST_PATH} \
-  --exclude "tf_model.h5" --exclude "flax_model.msgpack"
+  --exclude "tf_model.h5" "flax_model.msgpack"
 
 kubectl apply -f $REPO_DIR/test/e2e/engine-vllm-pvc/pvc.yaml
 

--- a/test/e2e/engine-vllm-pvc/test.sh
+++ b/test/e2e/engine-vllm-pvc/test.sh
@@ -13,6 +13,7 @@ mkdir -p ${PV_HOST_PATH}
 huggingface-cli download facebook/opt-125m --local-dir ${PV_HOST_PATH} \
   --exclude "tf_model.h5" "flax_model.msgpack"
 
+kubectl apply -f $REPO_DIR/test/e2e/engine-vllm-pvc/pv.yaml
 kubectl apply -f $REPO_DIR/test/e2e/engine-vllm-pvc/pvc.yaml
 
 helm install $models_release $REPO_DIR/charts/models -f - <<EOF

--- a/test/e2e/engine-vllm-pvc/test.sh
+++ b/test/e2e/engine-vllm-pvc/test.sh
@@ -30,6 +30,7 @@ EOF
 
 sleep 5
 
+# There are 2 replicas so send 10 requests to ensure that both replicas are used.
 for i in {1..10}; do
   echo "Sending request $i"
   curl http://localhost:8000/openai/v1/completions \

--- a/test/e2e/engine-vllm-pvc/test.sh
+++ b/test/e2e/engine-vllm-pvc/test.sh
@@ -6,7 +6,7 @@ models_release="kubeai-models"
 
 pip install -U "huggingface_hub[cli]"
 
-PV_HOST_PATH=/tmp/data
+PV_HOST_PATH=/tmp/model
 
 mkdir -p ${PV_HOST_PATH}
 
@@ -20,12 +20,15 @@ catalog:
   opt-125m-cpu:
     enabled: true
     url: pvc://model-pvc
-    minReplicas: 1
+    minReplicas: 2
 EOF
 
 sleep 5
 
-curl http://localhost:8000/openai/v1/completions \
-  --max-time 900 \
-  -H "Content-Type: application/json" \
-  -d '{"model": "opt-125m-cpu", "prompt": "Who was the first president of the United States?", "max_tokens": 40}'
+for i in {1..10}; do
+  echo "Sending request $i"
+  curl http://localhost:8000/openai/v1/completions \
+    --max-time 600 \
+    -H "Content-Type: application/json" \
+    -d '{"model": "opt-125m-cpu", "prompt": "Who was the first president of the United States?", "max_tokens": 40}'
+done

--- a/test/integration/model_validation_test.go
+++ b/test/integration/model_validation_test.go
@@ -264,6 +264,22 @@ func TestModelValidation(t *testing.T) {
 		},
 		{
 			model: v1.Model{
+				ObjectMeta: metadata("cache-profile-with-non-pvc-url-invalid"),
+				Spec: v1.ModelSpec{
+					URL:          "pvc://test-pvc/test-model",
+					Engine:       "VLLM",
+					Features:     []v1.ModelFeature{},
+					CacheProfile: "some-cache-profile",
+				},
+			},
+			expErrContains: []string{
+				"cacheProfile is only supported with urls of format",
+				"hf://",
+				"s3://",
+			},
+		},
+		{
+			model: v1.Model{
 				ObjectMeta: metadata("update-no-changes-valid"),
 				Spec: v1.ModelSpec{
 					URL:      "hf://test-repo/test-model",


### PR DESCRIPTION
Implements #311 
Fixes #303

Validation logic is implemented to prevent a Model with PVC source and cacheProfile from being admitted.

```
k apply -f - << EOF
apiVersion: kubeai.org/v1
kind: Model
metadata:
  name: opt-125m-cpu-pvc
  namespace: default
spec:
  engine: VLLM
  features:
  - TextGeneration
  minReplicas: 2
  replicas: 2
  resourceProfile: cpu:1
  scaleDownDelaySeconds: 30
  targetRequests: 100
  url: pvc://model-pvc
  cacheProfile: test
EOF
The Model "opt-125m-cpu-pvc" is invalid: spec: Invalid value: "object": cacheProfile is only supported with urls of format "hf://...", "s3://...", "gs://...", or "oss://..." at the moment.
```