### PR TITLE
feat(charts/kubeai): Add NodePort and LoadBalancer support with optional port value for kubeai and openwebui services

### DIFF
--- a/charts/kubeai/charts/openwebui/templates/service.yaml
+++ b/charts/kubeai/charts/openwebui/templates/service.yaml
@@ -11,10 +11,8 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      {{ if or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer") }}
-      {{ if .Values.service.nodePort }}
-      nodePort: {{ .Values.service.nodePort }}
-      {{ end }}
-      {{ end }}
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "openwebui.selectorLabels" . | nindent 4 }}

--- a/charts/kubeai/charts/openwebui/templates/service.yaml
+++ b/charts/kubeai/charts/openwebui/templates/service.yaml
@@ -7,9 +7,14 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      name: http
+      {{ if or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer") }}
+      {{ if .Values.service.httpNodePort }}
+      nodePort: {{ .Values.service.httpNodePort }}
+      {{ end }}
+      {{ end }}
   selector:
     {{- include "openwebui.selectorLabels" . | nindent 4 }}

--- a/charts/kubeai/charts/openwebui/templates/service.yaml
+++ b/charts/kubeai/charts/openwebui/templates/service.yaml
@@ -12,8 +12,8 @@ spec:
       targetPort: http
       protocol: TCP
       {{ if or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer") }}
-      {{ if .Values.service.httpNodePort }}
-      nodePort: {{ .Values.service.httpNodePort }}
+      {{ if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
       {{ end }}
       {{ end }}
   selector:

--- a/charts/kubeai/charts/openwebui/values.yaml
+++ b/charts/kubeai/charts/openwebui/values.yaml
@@ -43,7 +43,7 @@ service:
   type: ClusterIP
   port: 80
   # openwebui nodeport (Optional): Specify NodePort for openwebui if Nodeport or LoadBalancer service type (leave empty for random assignment)
-  httpNodePort: ""
+  nodePort: ""
 
 ingress:
   enabled: false

--- a/charts/kubeai/charts/openwebui/values.yaml
+++ b/charts/kubeai/charts/openwebui/values.yaml
@@ -42,6 +42,8 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+  # openwebui nodeport (Optional): Specify NodePort for openwebui if Nodeport or LoadBalancer service type (leave empty for random assignment)
+  httpNodePort: ""
 
 ingress:
   enabled: false

--- a/charts/kubeai/templates/service.yaml
+++ b/charts/kubeai/templates/service.yaml
@@ -7,13 +7,23 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      name: http
-    - port: 8080
+      {{ if or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer") }}
+      {{ if .Values.service.httpNodePort }}
+      nodePort: {{ .Values.service.httpNodePort }}
+      {{ end }}
+      {{ end }}
+    - name: http-metrics
+      port: 8080
       targetPort: 8080
       protocol: TCP
-      name: http-metrics
+      {{ if or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer") }}
+      {{ if .Values.service.metricsNodePort }}
+      nodePort: {{ .Values.service.metricsNodePort }}
+      {{ end }}
+      {{ end }}
   selector:
     {{- include "kubeai.selectorLabels" . | nindent 4 }}

--- a/charts/kubeai/templates/service.yaml
+++ b/charts/kubeai/templates/service.yaml
@@ -11,19 +11,15 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      {{ if or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer") }}
-      {{ if .Values.service.nodePort }}
-      nodePort: {{ .Values.service.nodePort }}
-      {{ end }}
-      {{ end }}
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
     - name: http-metrics
       port: 8080
       targetPort: 8080
       protocol: TCP
-      {{ if or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer") }}
-      {{ if .Values.service.metricsNodePort }}
-      nodePort: {{ .Values.service.metricsNodePort }}
-      {{ end }}
-      {{ end }}
+      {{- with .Values.service.metricsNodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "kubeai.selectorLabels" . | nindent 4 }}

--- a/charts/kubeai/templates/service.yaml
+++ b/charts/kubeai/templates/service.yaml
@@ -14,12 +14,5 @@ spec:
       {{- with .Values.service.nodePort }}
       nodePort: {{ . }}
       {{- end }}
-    - name: http-metrics
-      port: 8080
-      targetPort: 8080
-      protocol: TCP
-      {{- with .Values.service.metricsNodePort }}
-      nodePort: {{ . }}
-      {{- end }}
   selector:
     {{- include "kubeai.selectorLabels" . | nindent 4 }}

--- a/charts/kubeai/templates/service.yaml
+++ b/charts/kubeai/templates/service.yaml
@@ -12,8 +12,8 @@ spec:
       targetPort: http
       protocol: TCP
       {{ if or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer") }}
-      {{ if .Values.service.httpNodePort }}
-      nodePort: {{ .Values.service.httpNodePort }}
+      {{ if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
       {{ end }}
       {{ end }}
     - name: http-metrics

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -197,7 +197,13 @@ messaging:
 
 # Configure the openwebui subchart.
 openwebui:
+  enabled: true
   fullnameOverride: "openwebui"
+  service:
+    type: ClusterIP  # ClusterIP, NodePort, LoadBalancer
+    port: 80
+    # openwebui nodeport (Optional): Specify NodePort for openwebui if Nodeport or LoadBalancer service type (leave empty for random assignment)
+    httpNodePort: ""
   image:
     tag: v0.3.19
   env:
@@ -284,8 +290,12 @@ securityContext:
   # runAsUser: 1000
 
 service:
-  type: ClusterIP
+  type: ClusterIP  # ClusterIP, NodePort, LoadBalancer
   port: 80
+  # kubeai nodeport (Optional): Specify NodePort for kubeai if Nodeport or LoadBalancer service type (leave empty for random assignment)
+  httpNodePort: ""
+  # metrics nodeport (Optional): Specify a nodePort for Metrics if Nodeport or LoadBalancer service type (leave empty for random assignment)
+  metricsNodePort: ""
 
 ingress:
   enabled: false

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -197,7 +197,6 @@ messaging:
 
 # Configure the openwebui subchart.
 openwebui:
-  enabled: true
   fullnameOverride: "openwebui"
   service:
     type: ClusterIP  # ClusterIP, NodePort, LoadBalancer

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -203,7 +203,7 @@ openwebui:
     type: ClusterIP  # ClusterIP, NodePort, LoadBalancer
     port: 80
     # openwebui nodeport (Optional): Specify NodePort for openwebui if Nodeport or LoadBalancer service type (leave empty for random assignment)
-    httpNodePort: ""
+    nodePort: ""
   image:
     tag: v0.3.19
   env:
@@ -293,7 +293,7 @@ service:
   type: ClusterIP  # ClusterIP, NodePort, LoadBalancer
   port: 80
   # kubeai nodeport (Optional): Specify NodePort for kubeai if Nodeport or LoadBalancer service type (leave empty for random assignment)
-  httpNodePort: ""
+  nodePort: ""
   # metrics nodeport (Optional): Specify a nodePort for Metrics if Nodeport or LoadBalancer service type (leave empty for random assignment)
   metricsNodePort: ""
 

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -293,8 +293,6 @@ service:
   port: 80
   # kubeai nodeport (Optional): Specify NodePort for kubeai if Nodeport or LoadBalancer service type (leave empty for random assignment)
   nodePort: ""
-  # metrics nodeport (Optional): Specify a nodePort for Metrics if Nodeport or LoadBalancer service type (leave empty for random assignment)
-  metricsNodePort: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary
Enhanced `kubeai` and `openwebui` Helm charts to support `NodePort` and `LoadBalancer` types with optional custom `nodePort` values for consistent and flexible service exposure.

## What’s been done?
1. **`kubeai` chart**:
   - Added support for `NodePort` and `LoadBalancer` in `service.yaml`.
   - Introduced `httpNodePort` and `metricsNodePort` in `values.yaml` for optional custom ports.

2. **`openwebui`  subchart**:
   - Added support for `NodePort` and `LoadBalancer` in `service.yaml`.
   - Introduced `httpNodePort` in `values.yaml` for optional custom HTTP ports.

## Why is this useful?
- Allows exposing services outside the cluster using `NodePort` or `LoadBalancer` while Enabling custom `nodePort` configuration for better flexibility.
- Provides an easier solution to maintain consistent port exposure across upgrades or redeployments.
- Maintains backward compatibility with default `ClusterIP` behavior.

## How has it been tested
- Using `helm upgrade --dry-run` with different service types (`ClusterIP`, `NodePort`, `LoadBalancer`) and nodeports values euther specified and unspecified and validate rendered templates.
- Deploy and confirm `nodePort` values via `kubectl describe svc`.

_Notes:_
- feedback is welcome! 😊
- This is my first contribution to this project
