### PR TITLE
Adding a cache folder for local downloads of hugging-face models

### DIFF
--- a/components/model-loader/load.sh
+++ b/components/model-loader/load.sh
@@ -20,8 +20,10 @@ fi
 # Download
 case $src in
     "hf://"*)
+        local_cache="/cache"
         repo=${src#hf://}
-        huggingface-cli download --local-dir $dir $repo
+        mkdir -p "${local_cache}"
+        huggingface-cli download --local-dir $dir $repo --cache-dir $local_cache
         rm -rf $dir/.cache
         ;;
     "s3://"*)


### PR DESCRIPTION
# Overview

When downloading large models from huggingface, the `hugging-face-cli` uses a cache in `~/.local/<many>/<paths>/<deep>`. Sufficiently large enough models will exhaust the free space in the container.

# Fix

This update will create a folder at `/cache` if the folder does not exist. The folder will be used by `hugging-face-cli` as a spot to put the bytes during download. Nothing will change functionally if no changes to YAML config. However, this enables the use of a temp-volume with expanded space for the time of the `Job` being alive

# Example

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: download-model-job
spec:
  template:
    spec:
      containers:
        - name: downloader
          image: ghcr.io/substratusai/kubeai-model-loader:main
          args:
            - hf://neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8 # Source
            - /data
          volumeMounts:
            - name: model-volume
              mountPath: /data
            - name: local-cache   # <--- NOTE: Providing a mounted volume that is an emptyDir with space. Will disappear automatically when job completes
              mountPath: /cache
      volumes:
        - name: model-volume
          persistentVolumeClaim:
            claimName: gdc-llama-3-2-11b
        - name: local-cache
          emptyDir:
            sizeLimit: 1Gi
      restartPolicy: Never
``` 