### PR TITLE
adding support for 4090 founders edition

### DIFF
--- a/charts/kubeai/values-nvidia-k8s-device-plugin.yaml
+++ b/charts/kubeai/values-nvidia-k8s-device-plugin.yaml
@@ -27,3 +27,7 @@ resourceProfiles:
     nodeSelector:
       nvidia.com/gpu.family: "ampere"
       nvidia.com/gpu.memory: "8188"
+  nvidia-gpu-rtx4090-24gb:
+    nodeSelector:
+      nvidia.com/gpu.family: "ampere"
+      nvidia.com/gpu.memory: "24564"


### PR DESCRIPTION
This is to add support a NVIDIA 4090 FE 

Relevant labels after running a kind cluster with local kind from https://www.substratus.ai/blog/kind-with-gpus:
```
Labels:        
                    nvidia.com/gpu.family=ampere
                    nvidia.com/gpu.machine=kind
                    nvidia.com/gpu.memory=24564
                    nvidia.com/gpu.present=true
                    nvidia.com/gpu.product=NVIDIA-GeForce-RTX-4090
                    
```