### PR TITLE
Add annotations to service

### DIFF
--- a/charts/kubeai/templates/service.yaml
+++ b/charts/kubeai/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "kubeai.fullname" . }}
   labels:
     {{- include "kubeai.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -295,6 +295,7 @@ service:
   port: 80
   # kubeai nodeport (Optional): Specify NodePort for kubeai if Nodeport or LoadBalancer service type (leave empty for random assignment)
   nodePort: ""
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
This PR will add annotations to the service config in the KubeAI Helm chart. Cloud providers utilize annotations to configure their loadbalancers so it is important to be able to have the functionality of adding annotations to the service. 