### PR TITLE
Update CPU resourceProfile to use 4Gi mem and fix cpu model profiles

### DIFF
--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -93,9 +93,9 @@ resourceProfiles:
     imageName: "cpu"
     requests:
       cpu: 1
-      # TODO: Consider making this a ratio that is more common on cloud machines
-      # such as 1:4 CPU:Mem. NOTE: This might need to be adjusted for local clusters.
-      memory: "2Gi"
+      # A 1 CPU to 4Gi ratio is the most common on cloud machines.
+      # NOTE: This might need to be adjusted for local clusters.
+      memory: "4Gi"
       # TODO: Consider adding eph storage requests/limits.
       # Perhaps this is just needed for GKE Autopilot which defaults
       # to 1Gi for CPU-only.

--- a/charts/models/values.yaml
+++ b/charts/models/values.yaml
@@ -32,10 +32,7 @@ catalog:
     features: ["TextEmbedding"]
     url: "hf://intfloat/e5-mistral-7b-instruct"
     engine: VLLM
-    # TODO: Adjust - the memory associated with this request is too low.
-    resourceProfile: cpu:1
-    args:
-    - --gpu-memory-utilization=0.9
+    resourceProfile: cpu:5
   # Gemma #
   gemma2-2b-cpu:
     enabled: false
@@ -76,9 +73,9 @@ catalog:
     features: ["TextGeneration"]
     url: "hf://meta-llama/Meta-Llama-3.1-8B-Instruct"
     engine: VLLM
-    resourceProfile: cpu:6
+    resourceProfile: cpu:7
     env:
-      VLLM_CPU_KVCACHE_SPACE: "4"
+      VLLM_CPU_KVCACHE_SPACE: "6"
     args:
     - --max-model-len=32768
     - --max-num-batched-token=32768
@@ -506,8 +503,9 @@ catalog:
     enabled: false
     features: ["TextGeneration"]
     url: "hf://facebook/opt-125m"
+    env:
+      VLLM_CPU_KVCACHE_SPACE: "2"
     engine: VLLM
-    # TODO: Adjust - the memory associated with this request is too low.
     resourceProfile: cpu:1
   opt-125m-l4:
     enabled: false
@@ -534,14 +532,13 @@ catalog:
     - --max-num-seqs=16
     - --quantization=fp8
     - --kv-cache-dtype=fp8
-    minReplicas: 1
     resourceProfile: nvidia-gpu-rtx4070-8gb:1
   qwen2.5-7b-cpu:
     enabled: false
     features: ["TextGeneration"]
     url: "ollama://qwen2.5:7b"
     engine: OLlama
-    resourceProfile: cpu:2
+    resourceProfile: cpu:3
   qwen2-500m-cpu:
     enabled: false
     features: ["TextGeneration"]

--- a/manifests/models/e5-mistral-7b-instruct-cpu.yaml
+++ b/manifests/models/e5-mistral-7b-instruct-cpu.yaml
@@ -7,6 +7,4 @@ spec:
   features: [TextEmbedding]
   url: hf://intfloat/e5-mistral-7b-instruct
   engine: VLLM
-  args:
-    - --gpu-memory-utilization=0.9
-  resourceProfile: cpu:1
+  resourceProfile: cpu:5

--- a/manifests/models/llama-3.1-8b-instruct-cpu.yaml
+++ b/manifests/models/llama-3.1-8b-instruct-cpu.yaml
@@ -11,5 +11,5 @@ spec:
     - --max-model-len=32768
     - --max-num-batched-token=32768
   env:
-    VLLM_CPU_KVCACHE_SPACE: "4"
-  resourceProfile: cpu:6
+    VLLM_CPU_KVCACHE_SPACE: "6"
+  resourceProfile: cpu:7

--- a/manifests/models/opt-125m-cpu.yaml
+++ b/manifests/models/opt-125m-cpu.yaml
@@ -7,4 +7,6 @@ spec:
   features: [TextGeneration]
   url: hf://facebook/opt-125m
   engine: VLLM
+  env:
+    VLLM_CPU_KVCACHE_SPACE: "2"
   resourceProfile: cpu:1

--- a/manifests/models/qwen2.5-7b-cpu.yaml
+++ b/manifests/models/qwen2.5-7b-cpu.yaml
@@ -7,4 +7,4 @@ spec:
   features: [TextGeneration]
   url: ollama://qwen2.5:7b
   engine: OLlama
-  resourceProfile: cpu:2
+  resourceProfile: cpu:3

--- a/manifests/models/qwen2.5-coder-1.5b-rtx4070-8gb.yaml
+++ b/manifests/models/qwen2.5-coder-1.5b-rtx4070-8gb.yaml
@@ -14,5 +14,4 @@ spec:
     - --kv-cache-dtype=fp8
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
-  minReplicas: 1
   resourceProfile: nvidia-gpu-rtx4070-8gb:1


### PR DESCRIPTION
Tested the CPU models to see what memory requirements they had (`kubectl top pods`). Updated the `cpu` resourceProfile to request 4Gi of memory per core. This matches common cloud machine shapes and avoids the need to specify a extremely high `cpu:N` resourceProfile for models to match their memory requirements.

Fixes #418 - Which turned out to be an OOM issue (error appears to have been suppressed).