### PR TITLE
Add imagePullSecrets Support for Model Pods

### DIFF
--- a/charts/kubeai/templates/configmap.yaml
+++ b/charts/kubeai/templates/configmap.yaml
@@ -31,6 +31,10 @@ data:
       securityContext:
         {{- .Values.modelServerPods.securityContext | toYaml | nindent 8}}
       {{- end}}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8}}
+      {{- end}}
       {{- end}}
       serviceAccountName: {{ include "models.serviceAccountName" . }}
     modelAutoscaling:

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -252,6 +252,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# The imagePullSecrets will be used to pull both the kubeai controller image and the model images.
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: "kubeai"

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -242,4 +242,7 @@ type ModelServerPods struct {
 
 	// Security Context for the model pod containers
 	ModelContainerSecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
+
+	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any of the images
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }

--- a/internal/modelcontroller/engine_fasterwhisper.go
+++ b/internal/modelcontroller/engine_fasterwhisper.go
@@ -60,6 +60,7 @@ func (r *ModelReconciler) fasterWhisperPodForModel(m *kubeaiv1.Model, c ModelCon
 			RuntimeClassName:   c.RuntimeClassName,
 			ServiceAccountName: r.ModelServerPods.ModelServiceAccountName,
 			SecurityContext:    r.ModelServerPods.ModelPodSecurityContext,
+			ImagePullSecrets:   r.ModelServerPods.ImagePullSecrets,
 			Containers: []corev1.Container{
 				{
 					Name:            serverContainerName,

--- a/internal/modelcontroller/engine_infinity.go
+++ b/internal/modelcontroller/engine_infinity.go
@@ -78,6 +78,7 @@ func (r *ModelReconciler) infinityPodForModel(m *kubeaiv1.Model, c ModelConfig) 
 			RuntimeClassName:   c.RuntimeClassName,
 			ServiceAccountName: r.ModelServerPods.ModelServiceAccountName,
 			SecurityContext:    r.ModelServerPods.ModelPodSecurityContext,
+			ImagePullSecrets:   r.ModelServerPods.ImagePullSecrets,
 			Containers: []corev1.Container{
 				{
 					Name:  serverContainerName,

--- a/internal/modelcontroller/engine_ollama.go
+++ b/internal/modelcontroller/engine_ollama.go
@@ -82,6 +82,7 @@ func (r *ModelReconciler) oLlamaPodForModel(m *kubeaiv1.Model, c ModelConfig) *c
 			RuntimeClassName:   c.RuntimeClassName,
 			ServiceAccountName: r.ModelServerPods.ModelServiceAccountName,
 			SecurityContext:    r.ModelServerPods.ModelPodSecurityContext,
+			ImagePullSecrets:   r.ModelServerPods.ImagePullSecrets,
 			Containers: []corev1.Container{
 				{
 					Name:            serverContainerName,

--- a/internal/modelcontroller/engine_vllm.go
+++ b/internal/modelcontroller/engine_vllm.go
@@ -69,6 +69,7 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 			RuntimeClassName:   c.RuntimeClassName,
 			ServiceAccountName: r.ModelServerPods.ModelServiceAccountName,
 			SecurityContext:    r.ModelServerPods.ModelPodSecurityContext,
+			ImagePullSecrets:   r.ModelServerPods.ImagePullSecrets,
 			Containers: []corev1.Container{
 				{
 					Name:            serverContainerName,

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -179,6 +179,19 @@ func baseSysCfg(t *testing.T) config.System {
 		ModelLoading: config.ModelLoading{
 			Image: "model-loader",
 		},
+		ModelServerPods: config.ModelServerPods{
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: "test-secret1"},
+				{Name: "test-secret2"},
+			},
+			ModelServiceAccountName: "test-service-account",
+			ModelPodSecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: ptr.To(true),
+			},
+			ModelContainerSecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.To(false),
+			},
+		},
 		ResourceProfiles: map[string]config.ResourceProfile{
 			resourceProfileCPU: {
 				Requests: corev1.ResourceList{

--- a/test/integration/model_profiles_test.go
+++ b/test/integration/model_profiles_test.go
@@ -52,7 +52,12 @@ func TestModelProfiles(t *testing.T) {
 		assert.Contains(t, pod.Spec.Tolerations, sysCfg.ResourceProfiles[resourceProfileCPU].Tolerations[0])
 		assert.Equal(t, sysCfg.ResourceProfiles[resourceProfileCPU].Affinity, pod.Spec.Affinity)
 		assert.Equal(t, sysCfg.ResourceProfiles[resourceProfileCPU].NodeSelector, pod.Spec.NodeSelector)
-	}, 5*time.Second, time.Second/10, "Resource profile should be applied to the model Pod object")
+		// Verify all ModelServerPods settings are correctly propagated
+		assert.Equal(t, sysCfg.ModelServerPods.ImagePullSecrets, pod.Spec.ImagePullSecrets)
+		assert.Equal(t, sysCfg.ModelServerPods.ModelServiceAccountName, pod.Spec.ServiceAccountName)
+		assert.Equal(t, sysCfg.ModelServerPods.ModelPodSecurityContext, pod.Spec.SecurityContext)
+		assert.Equal(t, sysCfg.ModelServerPods.ModelContainerSecurityContext, container.SecurityContext)
+	}, 5*time.Second, time.Second/10, "Resource profile and ModelServerPods settings should be applied to the model Pod object")
 
 	const userImage = "my-repo.com/my-repo/my-image:latest"
 	require.EventuallyWithT(t, func(t *assert.CollectT) {


### PR DESCRIPTION
# Add imagePullSecrets Support for Model Pods
## Description

This PR adds support for propagating imagePullSecrets from the main KubeAI configuration to model pods. This enables model pods to pull images from private registries using the same credentials as the main server.

## Changes

- Added `ImagePullSecrets` field to `ModelServerPods` configuration struct
- Updated chart values.yaml to document imagePullSecrets
-  Updated Helm chart configmap template to pass imagePullSecrets from values to system config
- Updated model engine reconcilers to pass ImagePullSecrets to pod specifications
- Added integration tests to verify ImagePullSecrets propagation

## Example Usage

In your Helm values.yaml:
```yaml
imagePullSecrets:
- name: my-registry-secret
- name: another-registry-secret
```

The secrets will automatically be used by all model pods created by KubeAI.

## Related Issues
Closes #433 