### PR TITLE
add goatcounter analytics to kubeai.org website

### DIFF
--- a/docs/overrides/partials/integrations/analytics/custom.html
+++ b/docs/overrides/partials/integrations/analytics/custom.html
@@ -1,0 +1,2 @@
+<script data-goatcounter="https://kubeai.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/substratusai/kubeai
 
 theme:
   name: material
+  custom_dir: docs/overrides
   palette:
     primary: white # Defaults to indigo.
     accent: blue # Defaults to indigo.
@@ -54,3 +55,8 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde
+
+# Analytics tracking with GoatCounter
+extra:
+  analytics:
+    provider: custom


### PR DESCRIPTION
Privacy-aware; doesn’t track users with unique identifiers and doesn't need a GDPR notice.