### PR TITLE
fix: Include minReplicas even when value is 0

### DIFF
--- a/charts/models/templates/models.yaml
+++ b/charts/models/templates/models.yaml
@@ -30,9 +30,7 @@ spec:
   env:
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with $model.minReplicas }}
-  minReplicas: {{ . }}
-  {{- end }}
+  minReplicas: {{ default 0 $model.minReplicas }}
   {{- with $model.maxReplicas }}
   maxReplicas: {{ . }}
   {{- end}}

--- a/manifests/models/bge-embed-text-cpu.yaml
+++ b/manifests/models/bge-embed-text-cpu.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextEmbedding]
   url: hf://BAAI/bge-small-en-v1.5
   engine: Infinity
+  minReplicas: 0
   resourceProfile: cpu:1

--- a/manifests/models/deepseek-r1-1.5b-cpu.yaml
+++ b/manifests/models/deepseek-r1-1.5b-cpu.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextGeneration]
   url: ollama://deepseek-r1:1.5b
   engine: OLlama
+  minReplicas: 0
   resourceProfile: cpu:1

--- a/manifests/models/deepseek-r1-distill-llama-8b-l4.yaml
+++ b/manifests/models/deepseek-r1-distill-llama-8b-l4.yaml
@@ -18,4 +18,5 @@ spec:
     - --enforce-eager
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/deepseek-r1-distill-qwen-1.5b-rtx4070.yaml
+++ b/manifests/models/deepseek-r1-distill-qwen-1.5b-rtx4070.yaml
@@ -14,4 +14,5 @@ spec:
     - --kv-cache-dtype=fp8
   env:
     VLLM_USE_V1: "1"
+  minReplicas: 0
   resourceProfile: nvidia-gpu-rtx4070-8gb:1

--- a/manifests/models/deepseek-r1-mi300x.yaml
+++ b/manifests/models/deepseek-r1-mi300x.yaml
@@ -25,5 +25,6 @@ spec:
     TORCH_BLAS_PREFER_HIPBLASLT: "1"
     VLLM_FP8_PADDING: "0"
     VLLM_USE_TRITON_FLASH_ATTN: "0"
+  minReplicas: 0
   targetRequests: 1024
   resourceProfile: amd-gpu-mi300x:8

--- a/manifests/models/e5-mistral-7b-instruct-cpu.yaml
+++ b/manifests/models/e5-mistral-7b-instruct-cpu.yaml
@@ -9,4 +9,5 @@ spec:
   engine: VLLM
   args:
     - --gpu-memory-utilization=0.9
+  minReplicas: 0
   resourceProfile: cpu:1

--- a/manifests/models/faster-whisper-medium-en-cpu.yaml
+++ b/manifests/models/faster-whisper-medium-en-cpu.yaml
@@ -7,4 +7,5 @@ spec:
   features: [SpeechToText]
   url: hf://Systran/faster-whisper-medium.en
   engine: FasterWhisper
+  minReplicas: 0
   resourceProfile: cpu:1

--- a/manifests/models/gemma-2-9b-it-fp8-l4.yaml
+++ b/manifests/models/gemma-2-9b-it-fp8-l4.yaml
@@ -15,4 +15,5 @@ spec:
     - --kv-cache-dtype=fp8
   env:
     VLLM_USE_V1: "1"
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/gemma-27b-ollama-l4.yaml
+++ b/manifests/models/gemma-27b-ollama-l4.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextGeneration]
   url: ollama://gemma2:27b
   engine: OLlama
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/gemma-2b-it-tpu.yaml
+++ b/manifests/models/gemma-2b-it-tpu.yaml
@@ -9,4 +9,5 @@ spec:
   engine: VLLM
   args:
     - --disable-log-requests
+  minReplicas: 0
   resourceProfile: google-tpu-v5e-1x1:1

--- a/manifests/models/gemma-9b-ollama-l4.yaml
+++ b/manifests/models/gemma-9b-ollama-l4.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextGeneration]
   url: ollama://gemma2:9b
   engine: OLlama
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/gemma2-2b-cpu.yaml
+++ b/manifests/models/gemma2-2b-cpu.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextGeneration]
   url: ollama://gemma2:2b
   engine: OLlama
+  minReplicas: 0
   resourceProfile: cpu:2

--- a/manifests/models/granite-3.1-dense-ollama-l4.yaml
+++ b/manifests/models/granite-3.1-dense-ollama-l4.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextGeneration]
   url: ollama://granite3.1-dense
   engine: OLlama
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/llama-3.1-405b-instruct-fp8-a100-80b.yaml
+++ b/manifests/models/llama-3.1-405b-instruct-fp8-a100-80b.yaml
@@ -21,5 +21,6 @@ spec:
     - --num-scheduler-steps=8
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
+  minReplicas: 0
   targetRequests: 128
   resourceProfile: nvidia-gpu-a100-80gb:8

--- a/manifests/models/llama-3.1-405b-instruct-fp8-h100.yaml
+++ b/manifests/models/llama-3.1-405b-instruct-fp8-h100.yaml
@@ -16,5 +16,6 @@ spec:
     - --disable-log-requests
     - --max-num-seqs=1024
     - --kv-cache-dtype=fp8
+  minReplicas: 0
   targetRequests: 500
   resourceProfile: nvidia-gpu-h100:8

--- a/manifests/models/llama-3.1-405b-instruct-fp8-mi300x.yaml
+++ b/manifests/models/llama-3.1-405b-instruct-fp8-mi300x.yaml
@@ -23,5 +23,6 @@ spec:
     NCCL_MIN_NCHANNELS: "112"
     TORCH_BLAS_PREFER_HIPBLASLT: "1"
     VLLM_USE_TRITON_FLASH_ATTN: "0"
+  minReplicas: 0
   targetRequests: 1024
   resourceProfile: amd-gpu-mi300x:8

--- a/manifests/models/llama-3.1-70b-instruct-awq-int4-gh200.yaml
+++ b/manifests/models/llama-3.1-70b-instruct-awq-int4-gh200.yaml
@@ -12,5 +12,6 @@ spec:
     - --max-num-batched-token=16384
     - --enable-prefix-caching
     - --disable-log-requests
+  minReplicas: 0
   targetRequests: 50
   resourceProfile: nvidia-gpu-gh200:1

--- a/manifests/models/llama-3.1-70b-instruct-fp8-1-h100.yaml
+++ b/manifests/models/llama-3.1-70b-instruct-fp8-1-h100.yaml
@@ -14,4 +14,5 @@ spec:
     - --gpu-memory-utilization=0.95
     - --disable-log-requests
     - --kv-cache-dtype=fp8
+  minReplicas: 0
   resourceProfile: nvidia-gpu-h100:1

--- a/manifests/models/llama-3.1-70b-instruct-fp8-gh200.yaml
+++ b/manifests/models/llama-3.1-70b-instruct-fp8-gh200.yaml
@@ -19,5 +19,6 @@ spec:
     - --enforce-eager
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
+  minReplicas: 0
   targetRequests: 1024
   resourceProfile: nvidia-gpu-gh200:1

--- a/manifests/models/llama-3.1-70b-instruct-fp8-h100.yaml
+++ b/manifests/models/llama-3.1-70b-instruct-fp8-h100.yaml
@@ -15,5 +15,6 @@ spec:
     - --tensor-parallel-size=2
     - --enable-prefix-caching
     - --disable-log-requests
+  minReplicas: 0
   targetRequests: 500
   resourceProfile: nvidia-gpu-h100:2

--- a/manifests/models/llama-3.1-70b-instruct-fp8-l4.yaml
+++ b/manifests/models/llama-3.1-70b-instruct-fp8-l4.yaml
@@ -21,5 +21,6 @@ spec:
     - --enforce-eager
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
+  minReplicas: 0
   targetRequests: 500
   resourceProfile: nvidia-gpu-l4:8

--- a/manifests/models/llama-3.1-70b-instruct-fp8-mi300x.yaml
+++ b/manifests/models/llama-3.1-70b-instruct-fp8-mi300x.yaml
@@ -22,5 +22,6 @@ spec:
     NCCL_MIN_NCHANNELS: "112"
     TORCH_BLAS_PREFER_HIPBLASLT: "1"
     VLLM_USE_TRITON_FLASH_ATTN: "0"
+  minReplicas: 0
   targetRequests: 1024
   resourceProfile: amd-gpu-mi300x:1

--- a/manifests/models/llama-3.1-8b-instruct-cpu.yaml
+++ b/manifests/models/llama-3.1-8b-instruct-cpu.yaml
@@ -12,4 +12,5 @@ spec:
     - --max-num-batched-token=32768
   env:
     VLLM_CPU_KVCACHE_SPACE: "4"
+  minReplicas: 0
   resourceProfile: cpu:6

--- a/manifests/models/llama-3.1-8b-instruct-fp8-l4.yaml
+++ b/manifests/models/llama-3.1-8b-instruct-fp8-l4.yaml
@@ -12,4 +12,5 @@ spec:
     - --max-num-batched-token=16384
     - --gpu-memory-utilization=0.9
     - --disable-log-requests
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/llama-3.1-8b-instruct-tpu.yaml
+++ b/manifests/models/llama-3.1-8b-instruct-tpu.yaml
@@ -14,4 +14,5 @@ spec:
     - --num-scheduler-steps=4
     - --max-model-len=8192
     - --distributed-executor-backend=ray
+  minReplicas: 0
   resourceProfile: google-tpu-v5e-2x2:4

--- a/manifests/models/llama-3.1-supernova-lite-l4.yaml
+++ b/manifests/models/llama-3.1-supernova-lite-l4.yaml
@@ -18,4 +18,5 @@ spec:
     - --enforce-eager
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/llama-3.1-tulu-3-8b-l4.yaml
+++ b/manifests/models/llama-3.1-tulu-3-8b-l4.yaml
@@ -15,4 +15,5 @@ spec:
     - --kv-cache-dtype=fp8
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/llama-3.3-70b-instruct-bf16-gh200.yaml
+++ b/manifests/models/llama-3.3-70b-instruct-bf16-gh200.yaml
@@ -17,5 +17,6 @@ spec:
     - --disable-log-requests
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
+  minReplicas: 0
   targetRequests: 200
   resourceProfile: nvidia-gpu-gh200:1

--- a/manifests/models/llama-3.3-70b-ollama-l4.yaml
+++ b/manifests/models/llama-3.3-70b-ollama-l4.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextGeneration]
   url: ollama://llama3.3:70b
   engine: OLlama
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/mistral-small-24b-instruct-h100.yaml
+++ b/manifests/models/mistral-small-24b-instruct-h100.yaml
@@ -15,4 +15,5 @@ spec:
     - --disable-log-requests
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
+  minReplicas: 0
   resourceProfile: nvidia-gpu-h100:1

--- a/manifests/models/mistral-small-3.1-24b-instruct-h100.yaml
+++ b/manifests/models/mistral-small-3.1-24b-instruct-h100.yaml
@@ -17,4 +17,5 @@ spec:
     - --config-format=mistral
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
+  minReplicas: 0
   resourceProfile: nvidia-gpu-h100:1

--- a/manifests/models/nomic-embed-text-cpu.yaml
+++ b/manifests/models/nomic-embed-text-cpu.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextEmbedding]
   url: ollama://nomic-embed-text
   engine: OLlama
+  minReplicas: 0
   resourceProfile: cpu:1

--- a/manifests/models/opt-125m-cpu.yaml
+++ b/manifests/models/opt-125m-cpu.yaml
@@ -9,6 +9,7 @@ spec:
   engine: VLLM
   args:
     - --chat-template=/config/chat-template.jinja
+  minReplicas: 0
   resourceProfile: cpu:1
   files:
     - content: |-

--- a/manifests/models/opt-125m-l4.yaml
+++ b/manifests/models/opt-125m-l4.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextGeneration]
   url: hf://facebook/opt-125m
   engine: VLLM
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/phi-4-bnb-4bit-l4.yaml
+++ b/manifests/models/phi-4-bnb-4bit-l4.yaml
@@ -18,4 +18,5 @@ spec:
     - --load_format=bitsandbytes
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/phi-4-ollama-l4.yaml
+++ b/manifests/models/phi-4-ollama-l4.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextGeneration]
   url: ollama://phi4
   engine: OLlama
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/qwen2-500m-cpu.yaml
+++ b/manifests/models/qwen2-500m-cpu.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextGeneration]
   url: ollama://qwen2:0.5b
   engine: OLlama
+  minReplicas: 0
   resourceProfile: cpu:1

--- a/manifests/models/qwen2.5-7b-cpu.yaml
+++ b/manifests/models/qwen2.5-7b-cpu.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextGeneration]
   url: ollama://qwen2.5:7b
   engine: OLlama
+  minReplicas: 0
   resourceProfile: cpu:2

--- a/manifests/models/qwen2.5-7b-instruct-l4.yaml
+++ b/manifests/models/qwen2.5-7b-instruct-l4.yaml
@@ -16,4 +16,5 @@ spec:
     - --enable-prefix-caching
   env:
     VLLM_ATTENTION_BACKEND: FLASHINFER
+  minReplicas: 0
   resourceProfile: nvidia-gpu-l4:1

--- a/manifests/models/qwen2.5-coder-1.5b-cpu.yaml
+++ b/manifests/models/qwen2.5-coder-1.5b-cpu.yaml
@@ -7,4 +7,5 @@ spec:
   features: [TextGeneration]
   url: ollama://qwen2.5-coder:1.5b
   engine: OLlama
+  minReplicas: 0
   resourceProfile: cpu:1


### PR DESCRIPTION
## Issue
The current Helm template for models omits the `minReplicas` field when its value is set to 0. This happens because the Go template uses a `with` statement:

~~~yaml
{{- with $model.minReplicas }}
minReplicas: {{ . }}
{{- end }}
~~~

In Go templates, the integer value `0` is treated as "empty", causing the field to be completely absent from the generated Kubernetes resources.

## Impact
When `maxReplicas` is defined but `minReplicas` is missing, the Kubernetes validation fails with:

~~~
Error: failed to create resource: Model.kubeai.org is invalid: spec: Invalid value: "object": no such key: minReplicas evaluating rule: minReplicas should be less than or equal to maxReplicas.
~~~

This prevents models from being deployed with scaling configurations that use `minReplicas: 0` (scale-to-zero), which is a common pattern for efficient resource usage.

## Solution
Replace the conditional inclusion with a default value approach to ensure the field is always present:

~~~yaml
minReplicas: {{ default 0 $model.minReplicas }}
~~~

This guarantees that the field is included in the YAML even when the value is 0, satisfying the Kubernetes validation rule.

## Testing
Tested by deploying models with `minReplicas: 0` configurations, confirming they now pass validation and deploy successfully.

This example fails on the current version, but succeeds with the PR code:

```yaml
# CPU
deepseek-r1-1.5b-cpu:
  enabled: true
  features: [TextGeneration]
  url: "hf://deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
  engine: VLLM
  minReplicas: 0
  maxReplicas: 1
```