### PR TITLE
fix(helm): fix wrong name for key 'accessKeyID' in aws secret

### DIFF
--- a/charts/kubeai/templates/aws-secret.yaml
+++ b/charts/kubeai/templates/aws-secret.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
     {{- include "kubeai.labels" . | nindent 4 }}
 data:
-  accessKeyId: {{ .Values.secrets.aws.accessKeyId | b64enc }}
+  accessKeyID: {{ .Values.secrets.aws.accessKeyID | b64enc }}
   secretAccessKey: {{ .Values.secrets.aws.secretAccessKey | b64enc }}
 {{- end }}


### PR DESCRIPTION
In the Helm Chart the AWS secret is generated with an incorrect key. With this PR the secret is generated with the correct key 'accessKeyID'.