### PR TITLE
fix: support accessing models from private S3 buckets

### DIFF
--- a/internal/modelcontroller/model_source.go
+++ b/internal/modelcontroller/model_source.go
@@ -215,7 +215,7 @@ func (r *ModelReconciler) pvcPodAdditions(url modelURL) *modelSourcePodAdditions
 	}
 }
 
-var modelURLRegex = regexp.MustCompile(`^([a-z]+):\/\/([^?]+)(\?.*)?$`)
+var modelURLRegex = regexp.MustCompile(`^([a-z0-9]+):\/\/([^?]+)(\?.*)?$`)
 
 func parseModelURL(urlStr string) (modelURL, error) {
 	matches := modelURLRegex.FindStringSubmatch(urlStr)


### PR DESCRIPTION
Regular expression  [`^([a-z]+):\/\/([^?]+)(\?.*)?$`](https://github.com/substratusai/kubeai/blob/d4608a6f06c434fb02c67a87de0881d602d046fd/internal/modelcontroller/model_source.go#L218)  doesn't allow loading models from S3.

This PR fixes the problem.