### PR TITLE
update vLLM GH200 image to 0.8.2

### DIFF
--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -44,10 +44,8 @@ modelServers:
       cpu: "substratusai/vllm:v0.6.3.post1-cpu"
       google-tpu: "substratusai/vllm:v0.6.4.post1-tpu"
       nvidia-gpu: "vllm/vllm-openai:v0.8.2"
-      # TODO (samos123) switch to the official image when it is available.
-      # Source: https://github.com/drikster80/vllm/tree/gh200-docker
-      # gh200: "drikster80/vllm-gh200-openai:v0.6.4.post1"
-      gh200: "substratusai/vllm-gh200-openai:v0.6.4.post1"
+      # Source: https://github.com/substratusai/vllm-docker/blob/main/Dockerfile.cuda-arm
+      gh200: "substratusai/vllm-gh200:v0.8.2"
       # upstream vLLM seems to have broken ROCm support, so we are using a fork from AMD.
       # Source: https://hub.docker.com/r/rocm/vllm-dev
       # Source: https://github.com/ROCm/vllm

--- a/test/e2e/openai-python-client/requirements.txt
+++ b/test/e2e/openai-python-client/requirements.txt
@@ -1,2 +1,2 @@
 pytest==8.3.3
-openai==1.55.3
+openai==1.69.0

--- a/test/e2e/openai-python-client/test.py
+++ b/test/e2e/openai-python-client/test.py
@@ -8,7 +8,8 @@ client = OpenAI(base_url=base_url, api_key="ignored-by-kubeai")
 
 def test_list_models():
     response = client.models.list()
-    model_ids = [model.id for model in response.data]
+    # Access the data directly from the response object
+    model_ids = [m.id for m in response.data]
     assert model in model_ids
 
 

--- a/test/e2e/openai-python-client/test.py
+++ b/test/e2e/openai-python-client/test.py
@@ -8,8 +8,7 @@ client = OpenAI(base_url=base_url, api_key="ignored-by-kubeai")
 
 def test_list_models():
     response = client.models.list()
-    # Access the data directly from the response object
-    model_ids = [m.id for m in response.data]
+    model_ids = [model.id for model in response.data]
     assert model in model_ids
 
 


### PR DESCRIPTION
Also fixes the openai-python-client e2e test which needed to get a bump in version.