### PR TITLE
Load models and LoRA Adapters from S3 Compatible Storage Server

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
         - "engine-vllm-pvc"
         - "engine-ollama-pvc"
         - "model-files"
+        - "s3-model"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/internal/modelcontroller/model_source_test.go
+++ b/internal/modelcontroller/model_source_test.go
@@ -59,6 +59,15 @@ func Test_parseModelURL(t *testing.T) {
 				path:   "model-name",
 			},
 		},
+		"valid-s3": {
+			input: "s3://test-bucket/model-name",
+			want: modelURL{
+				scheme: "s3",
+				ref:    "test-bucket/model-name",
+				name:   "test-bucket",
+				path:   "model-name",
+			},
+		},
 		"valid-pvc": {
 			input: "pvc://my-vpc/path/to/model",
 			want: modelURL{

--- a/test/e2e/s3-model/model.yaml
+++ b/test/e2e/s3-model/model.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubeai.org/v1
+kind: Model
+metadata:
+  name: opt-125m-cpu
+spec:
+  features: [TextGeneration]
+  owner: facebook
+  url: s3://models/facebook/opt-125m
+  engine: VLLM
+  resourceProfile: cpu:1
+  minReplicas: 1
+  cacheProfile: e2e-test-kind-pv
+  env:
+    AWS_ENDPOINT_URL: http://s3:9000

--- a/test/e2e/s3-model/pv.yaml
+++ b/test/e2e/s3-model/pv.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kind-model-hostpath
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadOnlyMany
+    - ReadWriteOnce
+  hostPath:
+    path: /data
+    type: DirectoryOrCreate
+  persistentVolumeReclaimPolicy: Retain

--- a/test/e2e/s3-model/pvc.yaml
+++ b/test/e2e/s3-model/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-pvc
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 10Gi
+  volumeName: kind-model-hostpath

--- a/test/e2e/s3-model/s3-instance.yaml
+++ b/test/e2e/s3-model/s3-instance.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: s3
+spec:
+  selector:
+    app: s3
+  type: ClusterIP
+  ports:
+  - name: api
+    protocol: TCP
+    port: 9000
+    targetPort: 9000 
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: s3-config
+data:
+  seaweedfs_s3_config: |
+    {"identities":[{"name":"testuser","credentials":[{"accessKey":"testuser","secretKey":"testuser"}],"actions":["Admin","Read","Write"]}]}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: s3
+  name: s3
+spec:
+  containers:
+  - name: s3
+    image: chrislusf/seaweedfs:3.85
+    ports:
+        - containerPort: 9000
+    args: ["server", "-s3", "-s3.port", "9000"]
+    volumeMounts:
+      - mountPath: /etc/sw
+        name: s3-config
+  volumes:
+    - name: s3-config
+      configMap:
+        name: s3-config
+        
+

--- a/test/e2e/s3-model/skaffold.yaml
+++ b/test/e2e/s3-model/skaffold.yaml
@@ -1,0 +1,23 @@
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: kubeai-autoscaler-restart-test
+build:
+  artifacts:
+    - image: substratusai/kubeai
+  local:
+    push: false
+deploy:
+  helm:
+    releases:
+      - name: kubeai
+        chartPath: ./charts/kubeai
+        valuesFiles:
+          - ./test/e2e/s3-model/values.yaml
+        skipBuildDependencies: true
+portForward:
+  - resourceType: service
+    resourceName: kubeai
+    namespace: default
+    port: 80
+    localPort: 8000

--- a/test/e2e/s3-model/test.sh
+++ b/test/e2e/s3-model/test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+source $REPO_DIR/test/e2e/common.sh
+
+model="opt-125m-cpu"
+
+PV_HOST_PATH=/data
+
+kubectl apply -f $REPO_DIR/test/e2e/s3-model/pv.yaml
+kubectl apply -f $REPO_DIR/test/e2e/s3-model/pvc.yaml
+
+kubectl create -f $TEST_DIR/s3-instance.yaml
+kubectl wait --timeout=3m --for=condition=Ready pod/s3
+
+# Execute into the kind container
+kind_container=$(docker ps --filter "name=kind-control-plane" --format "{{.ID}}")
+docker exec -i $kind_container bash -c "
+  apt update -y && apt install -y python3-pip
+  pip install -U "huggingface_hub[cli]" --break-system-packages
+  mkdir -p ${PV_HOST_PATH}/models/facebook/opt-125m
+  huggingface-cli download facebook/opt-125m --local-dir ${PV_HOST_PATH}/models/facebook/opt-125m \
+    --exclude 'tf_model.h5' 'flax_model.msgpack'"
+
+kubectl create -f $TEST_DIR/upload-model-to-s3.yaml
+kubectl wait --for=condition=complete --timeout=120s job/upload-model-to-s3
+
+kubectl apply -f $TEST_DIR/model.yaml
+kubectl wait --timeout=5m --for=jsonpath='{.status.cache.loaded}'=true model/$model && \
+kubectl wait --timeout=20m --for=jsonpath='.status.replicas.ready'=1 model/${model}
+
+sleep 5
+
+# There are 1 replicas so send 10 requests to ensure that both replicas are used.
+for i in {1..5}; do
+  echo "Sending request $i"
+  curl http://localhost:8000/openai/v1/completions \
+    --max-time 600 \
+    -H "Content-Type: application/json" \
+    -d '{"model": "opt-125m-cpu", "prompt": "Who was the first president of the United States?", "max_tokens": 40}'
+done

--- a/test/e2e/s3-model/upload-model-to-s3.yaml
+++ b/test/e2e/s3-model/upload-model-to-s3.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: upload-model-to-s3
+  labels:
+    app: upload
+spec:
+  template:
+    metadata:
+      name: upload-model-to-s3
+      labels:
+        app: upload
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: wait-for-s3
+          image: curlimages/curl
+          command:
+            - sh 
+            - -c 
+          args:
+            - 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://s3:9000/status)" != "200" ]]; do sleep 10; echo "wait for s3"; sleep 5; done'
+      containers:
+      - name: s3-mc-model
+        image: amazon/aws-cli
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            value: testuser
+          - name: AWS_SECRET_ACCESS_KEY
+            value: testuser
+          - name: AWS_ENDPOINT_URL
+            value: http://s3:9000
+        # command: [ "/bin/bash", "-c", "--" ]
+        # args: [ "while true; do sleep 30; done;" ]
+        command:
+        - /bin/bash
+        - -c
+        args: 
+        - aws s3api create-bucket --bucket models && aws s3 sync /data/models/ s3://models/
+        volumeMounts:
+        - mountPath: /data
+          name: localvolume
+      volumes:
+      - name: localvolume
+        persistentVolumeClaim:
+          claimName: model-pvc

--- a/test/e2e/s3-model/values.yaml
+++ b/test/e2e/s3-model/values.yaml
@@ -1,0 +1,11 @@
+open-webui:
+  enabled: false
+secrets:
+  aws:
+    create: true
+    accessKeyID: "testuser"
+    secretAccessKey: "testuser"
+cacheProfiles:
+  e2e-test-kind-pv:
+    sharedFilesystem:
+      persistentVolumeName: "kind-hostpath"


### PR DESCRIPTION
Support load models and LoRA Adapters from non-AWS S3 Compatible Storage Server allowing users to specify the endpoint URL.

I've also added an e2e test to verify that loading models from s3 works. However I couldn't find a way to easily test the loading of adapters from s3.

Fixes: #451