### PR TITLE
fix: adds support for custom metrics apiVersion in kubeai helm chart

### DIFF
--- a/charts/kubeai/templates/vllm-pod-monitor.yaml
+++ b/charts/kubeai/templates/vllm-pod-monitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.metrics.prometheusOperator.vLLMPodMonitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ .Values.metrics.prometheusOperator.vLLMPodMonitor.apiVersion }}
 kind: PodMonitor
 metadata:
   name: {{ include "kubeai.fullname" . }}-vllm

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -84,6 +84,8 @@ metrics:
     vLLMPodMonitor:
       # Enable creation of PodMonitor resource that scrapes vLLM metrics endpoint.
       enabled: false
+      # Set the apiVersion to azmonitoring.coreos.com/v1 when using Azure Monitor managed service for Prometheus
+      apiVersion: monitoring.coreos.com/v1
       labels: {}
 
 resourceProfiles:


### PR DESCRIPTION
### Issue

The current helm template allows for vllm metrics to be scraped by prometheus. However, [Azure Managed Prometheus](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/prometheus-metrics-scrape-crd) uses the API version `azmonitoring.coreos.com/v1` instead of `monitoring.coreos.com/v1`. 

### Impact
Users of Azure Managed Prometheus cannot enable vllm metrics without drifting the chart.

### Solution

Added a key `metrics.prometheusOperator.vLLMPodMonitor.apiVersion` with a value of `monitoring.coreos.com/v1` to the default `values.yaml`. Amend the `vllm-pod-monitor.yaml` template and replace `monitoring.coreos.com/v1` with `{{ .Values.metrics.prometheusOperator.vLLMPodMonitor.apiVersion }}` It's also possible to set a default in the template, but chose to follow the existing pattern for defaults in this chart.

### Testing

We successfully deployed the forked kubeai 0.19.0 chart and could then see vllm metrics in Azure Managed Prometheus.
