### PR TITLE
Support envFrom in model spec

### DIFF
--- a/api/k8s/v1/model_types.go
+++ b/api/k8s/v1/model_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -85,6 +86,9 @@ type ModelSpec struct {
 
 	// Env variables to be added to the server process.
 	Env map[string]string `json:"env,omitempty"`
+
+	// Env variables to be added to the server process from Secret or ConfigMap.
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
 
 	// Replicas is the number of Pod replicas that should be actively
 	// serving the model. KubeAI will manage this field unless AutoscalingDisabled

--- a/api/k8s/v1/zz_generated.deepcopy.go
+++ b/api/k8s/v1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -152,6 +153,13 @@ func (in *ModelSpec) DeepCopyInto(out *ModelSpec) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = make([]corev1.EnvFromSource, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Replicas != nil {

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -90,6 +90,56 @@ spec:
                   type: string
                 description: Env variables to be added to the server process.
                 type: object
+              envFrom:
+                description: Env variables to be added to the server process from
+                  Secret or ConfigMap.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
               features:
                 description: |-
                   Features that the model supports.

--- a/docs/how-to/authenticate-to-model-repos.md
+++ b/docs/how-to/authenticate-to-model-repos.md
@@ -1,8 +1,10 @@
 # Authenticate to model repos
 
-KubeAI supports the following private model repositories.
+KubeAI supports the following private model repositories, and different authentication methods.
 
-## Alibaba Object Storage Service
+## Helm
+
+### Alibaba Object Storage Service
 
 Example url: `oss://my-oss-bucket/my-models/llama-3.1-8b-instruct`
 
@@ -19,7 +21,7 @@ helm upgrade --install kubeai kubeai/kubeai \
 
 **NOTE:** KubeAI does not automatically react to updates to credentials. You will need to manually delete and allow KubeAI to recreate any failed Jobs/Pods that required credentials.
 
-## Google Cloud Storage
+### Google Cloud Storage
 
 Example url: `gs://my-gcs-bucket/my-models/llama-3.1-8b-instruct`
 
@@ -35,7 +37,7 @@ helm upgrade --install kubeai kubeai/kubeai \
 
 **NOTE:** KubeAI does not automatically react to updates to credentials. You will need to manually delete and allow KubeAI to recreate any failed Jobs/Pods that required credentials.
 
-## HuggingFace Hub
+### HuggingFace Hub
 
 Example model url: `hf://meta-llama/Llama-3.1-8B-Instruct`
 
@@ -51,7 +53,7 @@ helm upgrade --install kubeai kubeai/kubeai \
 
 **NOTE:** KubeAI does not automatically react to updates to credentials. You will need to manually delete and allow KubeAI to recreate any failed Jobs/Pods that required credentials.
 
-## S3
+### S3
 
 Example model url: `s3://my-private-model-bucket/my-models/llama-3.1-8b-instruct`
 
@@ -67,3 +69,40 @@ helm upgrade --install kubeai kubeai/kubeai \
 ```
 
 **NOTE:** KubeAI does not automatically react to updates to credentials. You will need to manually delete and allow KubeAI to recreate any failed Jobs/Pods that required credentials.
+
+## Model Spec
+
+You can also pass credentials using envFrom in the model spec.
+This is an example how to confiure an S3 self managed instance with and envFrom.
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: set1
+type: kubernetes.io/basic-auth
+stringData:
+  AWS_ACCESS_KEY_ID: test
+  AWS_SECRET_ACCESS_KEY: testtest
+  HF_TOKEN: secret
+---
+apiVersion: kubeai.org/v1
+kind: Model
+metadata:
+  name: llama-test-s3
+spec:
+  features: [TextGeneration]
+  owner: meta-llama
+  url: s3://models/Llama-3.2-1B
+  adapters: # <--
+  - name: llama-adapter
+    url: s3://adapters/llama-3.1-8b-ocr-correction
+  engine: VLLM
+  env:
+    AWS_ENDPOINT_URL: http://locals3:9000
+  envFrom:
+    - secretRef:
+        name: set1
+```
+
+**NOTE:** If both configuration methods are used, the helm method takes precedence.

--- a/docs/reference/.kubernetes-api/config.yaml
+++ b/docs/reference/.kubernetes-api/config.yaml
@@ -8,4 +8,4 @@ processor:
 
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
-  kubernetesVersion: 1.30
+  kubernetesVersion: 1.31

--- a/docs/reference/kubernetes-api.md
+++ b/docs/reference/kubernetes-api.md
@@ -96,7 +96,7 @@ Model resources define the ML models that will be served by KubeAI.
 | --- | --- | --- | --- |
 | `apiVersion` _string_ | `kubeai.org/v1` | | |
 | `kind` _string_ | `Model` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
 | `spec` _[ModelSpec](#modelspec)_ |  |  |  |
 | `status` _[ModelStatus](#modelstatus)_ |  |  |  |
 
@@ -137,6 +137,7 @@ _Appears in:_
 | `image` _string_ | Image to be used for the server process.<br />Will be set from ResourceProfile + Engine if not specified. |  |  |
 | `args` _string array_ | Args to be added to the server process. |  |  |
 | `env` _object (keys:string, values:string)_ | Env variables to be added to the server process. |  |  |
+| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#envfromsource-v1-core) array_ | Env variables to be added to the server process from Secret or ConfigMap. |  |  |
 | `replicas` _integer_ | Replicas is the number of Pod replicas that should be actively<br />serving the model. KubeAI will manage this field unless AutoscalingDisabled<br />is set to true. |  |  |
 | `minReplicas` _integer_ | MinReplicas is the minimum number of Pod replicas that the model can scale down to.<br />Note: 0 is a valid value. |  | Minimum: 0 <br />Optional: \{\} <br /> |
 | `maxReplicas` _integer_ | MaxReplicas is the maximum number of Pod replicas that the model can scale up to.<br />Empty value means no limit. |  | Minimum: 1 <br /> |

--- a/internal/modelcontroller/adapters.go
+++ b/internal/modelcontroller/adapters.go
@@ -202,6 +202,7 @@ func (r *ModelReconciler) patchServerAdapterLoader(podSpec *corev1.PodSpec, m *v
 	}
 	podSpec.Containers = append(podSpec.Containers, loaderContainer)
 	r.modelAuthCredentialsForAllSources().applyToPodSpec(podSpec, len(podSpec.Containers)-1)
+	r.modelEnvFrom(m).applyToPodSpec(podSpec, len(podSpec.Containers)-1)
 }
 
 func getLabelledAdapters(pod *corev1.Pod) map[string]struct{} {

--- a/internal/modelcontroller/model_controller.go
+++ b/internal/modelcontroller/model_controller.go
@@ -300,6 +300,10 @@ func (r *ModelReconciler) getModelConfig(model *kubeaiv1.Model) (ModelConfig, er
 	result.Requests = requests
 	result.Limits = limits
 
+	if model.Spec.EnvFrom != nil {
+		result.Source.modelSourcePodAdditions.envFrom = model.Spec.EnvFrom
+	}
+
 	image, err := r.lookupServerImage(model, profile)
 	if err != nil {
 		return result, fmt.Errorf("looking up server image: %w", err)


### PR DESCRIPTION
Add support for envFrom paremeter in model spec, this would allow us to load environment variables from existing secrets or configmaps. 
Supporting envFrom could be useful in several scenarios, for example if you want to support different sets of credentials based on the model.

Example 1
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: set1
type: kubernetes.io/basic-auth
stringData:
  AWS_ACCESS_KEY_ID: test
  AWS_SECRET_ACCESS_KEY: testtest
  HF_TOKEN: secret
---
apiVersion: kubeai.org/v1
kind: Model
metadata:
  name: llama-test-s3
spec:
  features: [TextGeneration]
  owner: meta-llama
  url: hf://meta-llama/Llama-3.2-1B
  adapters: # <--
  - name: llama-adapter
    url: s3://models/llama-3.1-8b-ocr-correction
  engine: VLLM
  env:
    AWS_ENDPOINT_URL: http://locals3:9000
  envFrom:
    - secretRef:
        name: set1
```
Example 2
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: set2
type: kubernetes.io/basic-auth
stringData:
  AWS_ACCESS_KEY_ID: test
  AWS_SECRET_ACCESS_KEY: testtest
---
apiVersion: kubeai.org/v1
kind: Model
metadata:
  name: llama-test-s3
spec:
  features: [TextGeneration]
  owner: meta-llama
  url: s3://models/Meta-Llama-3.1-8B-Instruct-bnb-4bit
  engine: VLLM
  env:
    AWS_ENDPOINT_URL: http://locals3:9000
  envFrom:
    - secretRef:
        name: set2
```