### PR TITLE
fix flaky s3 test

### DIFF
--- a/test/e2e/s3-model/s3-instance.yaml
+++ b/test/e2e/s3-model/s3-instance.yaml
@@ -36,9 +36,15 @@ spec:
     volumeMounts:
       - mountPath: /etc/sw
         name: s3-config
+    resources:
+      limits:
+        cpu: "1"
+        memory: "2Gi"
+      requests:
+        cpu: "0.5"
+        memory: "1Gi"
   volumes:
     - name: s3-config
       configMap:
         name: s3-config
-        
 


### PR DESCRIPTION
See example of flaky test: https://github.com/substratusai/kubeai/actions/runs/14278117943/job/40024223305

```
+ kubectl delete -f /home/runner/work/kubeai/kubeai/test/e2e/s3-model/s3-instance.yaml
Error from server: error when deleting "/home/runner/work/kubeai/kubeai/test/e2e/s3-model/s3-instance.yaml": rpc error: code = Unavailable desc = error reading from server: EOF
Error from server (Timeout): error when deleting "/home/runner/work/kubeai/kubeai/test/e2e/s3-model/s3-instance.yaml": Timeout: request did not complete within requested timeout - context deadline exceeded
Error from server (Timeout): error when deleting "/home/runner/work/kubeai/kubeai/test/e2e/s3-model/s3-instance.yaml": Timeout: request did not complete within requested timeout - context deadline exceeded
```

It looks like the k8s cluster become fully unresponsive. This PR may fix it by adding a resource limit on the s3 instance.