### PR TITLE
support use of JSONPatch for model server pods

### DIFF
--- a/charts/kubeai/templates/configmap.yaml
+++ b/charts/kubeai/templates/configmap.yaml
@@ -27,6 +27,10 @@ data:
       podSecurityContext:
         {{- .Values.modelServerPods.podSecurityContext | toYaml | nindent 8}}
       {{- end}}
+      {{- if .Values.modelServerPods.podPatches }}
+      podPatches:
+        {{- .Values.modelServerPods.podPatches | toYaml | nindent 8}}
+      {{- end}}
       {{- if .Values.modelServerPods.securityContext }}
       securityContext:
         {{- .Values.modelServerPods.securityContext | toYaml | nindent 8}}

--- a/charts/kubeai/templates/configmap.yaml
+++ b/charts/kubeai/templates/configmap.yaml
@@ -27,9 +27,9 @@ data:
       podSecurityContext:
         {{- .Values.modelServerPods.podSecurityContext | toYaml | nindent 8}}
       {{- end}}
-      {{- if .Values.modelServerPods.podPatches }}
-      podPatches:
-        {{- .Values.modelServerPods.podPatches | toYaml | nindent 8}}
+      {{- if .Values.modelServerPods.jsonPatches }}
+      jsonPatches:
+        {{- .Values.modelServerPods.jsonPatches | toYaml | nindent 8}}
       {{- end}}
       {{- if .Values.modelServerPods.securityContext }}
       securityContext:

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -74,6 +74,11 @@ modelServerPods:
     capabilities:
       drop:
         - ALL
+  # JSON Patch to apply to the model server pods
+  # podPatches:
+  # - op: add
+  #   path: /spec/podPriorityClassName
+  #   value: kubeai-model-server
 
 modelRollouts:
   # The number of replicas to add when rolling out a new model.

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -74,8 +74,9 @@ modelServerPods:
     capabilities:
       drop:
         - ALL
-  # JSON Patch to apply to the model server pods
-  # podPatches:
+  # JSONPatch to apply to the model server pods
+  # Invalid patches will be ignored.
+  # jsonPatches:
   # - op: add
   #   path: /spec/priorityClassName
   #   value: kubeai-model-server

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -77,7 +77,7 @@ modelServerPods:
   # JSON Patch to apply to the model server pods
   # podPatches:
   # - op: add
-  #   path: /spec/podPriorityClassName
+  #   path: /spec/priorityClassName
   #   value: kubeai-model-server
 
 modelRollouts:

--- a/go.mod
+++ b/go.mod
@@ -152,6 +152,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240812133136-8ffd90a71988 // indirect
 	google.golang.org/grpc v1.65.0 // indirect
 	google.golang.org/protobuf v1.36.3 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -501,6 +501,8 @@ google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojt
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSPG+6V4=
+gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -233,7 +233,7 @@ type ModelLoading struct {
 	Image string `json:"image" validate:"required"`
 }
 
-type Patch struct {
+type JSONPatch struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`
 	Value interface{} `json:"value"`
@@ -252,8 +252,8 @@ type ModelServerPods struct {
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any of the images
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
-	// ModelPodPatches is a list of patches to apply to the model pod template.
+	// JSONPatches is a list of patches to apply to the model pod template.
 	// This is a JSON Patch as defined in RFC 6902.
 	// https://datatracker.ietf.org/doc/html/rfc6902
-	ModelPodPatches []Patch `json:"podPatches,omitempty"`
+	JSONPatches []JSONPatch `json:"jsonPatches,omitempty"`
 }

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -233,6 +233,12 @@ type ModelLoading struct {
 	Image string `json:"image" validate:"required"`
 }
 
+type Patch struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
 type ModelServerPods struct {
 	// The service account to use for all model pods
 	ModelServiceAccountName string `json:"serviceAccountName,omitempty"`
@@ -245,4 +251,9 @@ type ModelServerPods struct {
 
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any of the images
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+
+	// ModelPodPatches is a list of patches to apply to the model pod template.
+	// This is a JSON Patch as defined in RFC 6902.
+	// https://datatracker.ietf.org/doc/html/rfc6902
+	ModelPodPatches []Patch `json:"podPatch,omitempty"`
 }

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -255,5 +255,5 @@ type ModelServerPods struct {
 	// ModelPodPatches is a list of patches to apply to the model pod template.
 	// This is a JSON Patch as defined in RFC 6902.
 	// https://datatracker.ietf.org/doc/html/rfc6902
-	ModelPodPatches []Patch `json:"podPatch,omitempty"`
+	ModelPodPatches []Patch `json:"podPatches,omitempty"`
 }

--- a/internal/modelcontroller/model_controller.go
+++ b/internal/modelcontroller/model_controller.go
@@ -173,7 +173,7 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res 
 		}
 	}()
 
-	plan := r.calculatePodPlan(allPods, model, modelConfig)
+	plan := r.calculatePodPlan(ctx, allPods, model, modelConfig)
 	if plan.containsActions() {
 		var err error
 		scaled, err = plan.execute(ctx, r.Client, r.Scheme)

--- a/internal/modelcontroller/model_controller.go
+++ b/internal/modelcontroller/model_controller.go
@@ -173,7 +173,12 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res 
 		}
 	}()
 
-	plan := r.calculatePodPlan(ctx, allPods, model, modelConfig)
+	plan, err := r.calculatePodPlan(allPods, model, modelConfig)
+	if err != nil {
+		log.Error(err, "Failed to calculate pod plan")
+		return ctrl.Result{}, nil
+	}
+
 	if plan.containsActions() {
 		var err error
 		scaled, err = plan.execute(ctx, r.Client, r.Scheme)

--- a/internal/modelcontroller/patch.go
+++ b/internal/modelcontroller/patch.go
@@ -1,0 +1,42 @@
+package modelcontroller
+
+import (
+	"encoding/json"
+	"fmt"
+
+	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (r *ModelReconciler) patchPod(pod *corev1.Pod) error {
+	for _, p := range r.ModelServerPods.ModelPodPatches {
+		// Marshal the pod patch
+		pb, err := json.Marshal(p)
+		if err != nil {
+			return fmt.Errorf("marshal pod patch: %w", err)
+		}
+		// Decode the pod patch
+		patch, err := jsonpatch.DecodePatch(pb)
+		if err != nil {
+			return fmt.Errorf("decode pod patch: %w", err)
+		}
+		// Marshal the pod to be patched
+		podB, err := pod.Marshal()
+		if err != nil {
+			return fmt.Errorf("marshal pod: %w", err)
+		}
+
+		// Apply the patch to the pod
+		patchedPodB, err := patch.Apply(podB)
+		if err != nil {
+			return fmt.Errorf("apply pod patch: %w", err)
+		}
+		// Unmarshal the patched pod
+		patchedPod := &corev1.Pod{}
+		if err := json.Unmarshal(patchedPodB, patchedPod); err != nil {
+			return fmt.Errorf("unmarshal patched pod: %w", err)
+		}
+		pod = patchedPod
+	}
+	return nil
+}

--- a/internal/modelcontroller/patch.go
+++ b/internal/modelcontroller/patch.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func patchPod(patches []config.Patch, pod *corev1.Pod) error {
+func applyJSONPatchToPod(patches []config.JSONPatch, pod *corev1.Pod) error {
 	if len(patches) == 0 {
 		return nil
 	}
@@ -24,18 +24,18 @@ func patchPod(patches []config.Patch, pod *corev1.Pod) error {
 		return fmt.Errorf("decode pod patch: %w", err)
 	}
 
-	podB, err := json.Marshal(pod)
+	podJson, err := json.Marshal(pod)
 	if err != nil {
 		return fmt.Errorf("marshal pod: %w", err)
 	}
 
-	patchedPodB, err := patch.Apply(podB)
+	patchedPodJson, err := patch.Apply(podJson)
 	if err != nil {
 		return fmt.Errorf("apply pod patch: %w", err)
 	}
 
 	patchedPod := &corev1.Pod{}
-	if err := json.Unmarshal(patchedPodB, patchedPod); err != nil {
+	if err := json.Unmarshal(patchedPodJson, patchedPod); err != nil {
 		return fmt.Errorf("unmarshal patched pod: %w", err)
 	}
 	*pod = *patchedPod

--- a/internal/modelcontroller/patch.go
+++ b/internal/modelcontroller/patch.go
@@ -10,6 +10,10 @@ import (
 )
 
 func patchPod(patches []config.Patch, pod *corev1.Pod) error {
+	if len(patches) == 0 {
+		return nil
+	}
+
 	pb, err := json.Marshal(patches)
 	if err != nil {
 		return fmt.Errorf("marshal pod patch: %w", err)

--- a/internal/modelcontroller/patch.go
+++ b/internal/modelcontroller/patch.go
@@ -4,39 +4,36 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/substratusai/kubeai/internal/config"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (r *ModelReconciler) patchPod(pod *corev1.Pod) error {
-	for _, p := range r.ModelServerPods.ModelPodPatches {
-		// Marshal the pod patch
-		pb, err := json.Marshal(p)
-		if err != nil {
-			return fmt.Errorf("marshal pod patch: %w", err)
-		}
-		// Decode the pod patch
-		patch, err := jsonpatch.DecodePatch(pb)
-		if err != nil {
-			return fmt.Errorf("decode pod patch: %w", err)
-		}
-		// Marshal the pod to be patched
-		podB, err := pod.Marshal()
-		if err != nil {
-			return fmt.Errorf("marshal pod: %w", err)
-		}
-
-		// Apply the patch to the pod
-		patchedPodB, err := patch.Apply(podB)
-		if err != nil {
-			return fmt.Errorf("apply pod patch: %w", err)
-		}
-		// Unmarshal the patched pod
-		patchedPod := &corev1.Pod{}
-		if err := json.Unmarshal(patchedPodB, patchedPod); err != nil {
-			return fmt.Errorf("unmarshal patched pod: %w", err)
-		}
-		pod = patchedPod
+func patchPod(patches []config.Patch, pod *corev1.Pod) error {
+	pb, err := json.Marshal(patches)
+	if err != nil {
+		return fmt.Errorf("marshal pod patch: %w", err)
 	}
+
+	patch, err := jsonpatch.DecodePatch(pb)
+	if err != nil {
+		return fmt.Errorf("decode pod patch: %w", err)
+	}
+
+	podB, err := json.Marshal(pod)
+	if err != nil {
+		return fmt.Errorf("marshal pod: %w", err)
+	}
+
+	patchedPodB, err := patch.Apply(podB)
+	if err != nil {
+		return fmt.Errorf("apply pod patch: %w", err)
+	}
+
+	patchedPod := &corev1.Pod{}
+	if err := json.Unmarshal(patchedPodB, patchedPod); err != nil {
+		return fmt.Errorf("unmarshal patched pod: %w", err)
+	}
+	*pod = *patchedPod
 	return nil
 }

--- a/internal/modelcontroller/patch_test.go
+++ b/internal/modelcontroller/patch_test.go
@@ -77,8 +77,13 @@ func Test_patchPod(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := patchPod(c.patches, c.modelPod)
-			require.NoError(t, err)
+			err := applyJSONPatchToPod(c.patches, c.modelPod)
+			if c.errorString != nil {
+				require.ErrorContains(t, err, *c.errorString)
+			} else {
+				require.NoError(t, err)
+			}
+
 			require.Equal(t, c.want, c.modelPod, "expected pod to be patched correctly")
 		})
 	}

--- a/internal/modelcontroller/patch_test.go
+++ b/internal/modelcontroller/patch_test.go
@@ -10,14 +10,28 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func Test_patchPod(t *testing.T) {
+func Test_applyJSONPatchToPod(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]struct {
-		modelPod *corev1.Pod
-		patches  []config.Patch
-		want     *corev1.Pod
+		modelPod    *corev1.Pod
+		patches     []config.JSONPatch
+		want        *corev1.Pod
+		errorString *string
 	}{
+		"no-patch": {
+			modelPod: &corev1.Pod{},
+			patches:  nil,
+			want:     &corev1.Pod{},
+		},
+		"error-patch": {
+			modelPod: &corev1.Pod{},
+			patches: []config.JSONPatch{
+				{Op: "invalid", Path: "/spec/containers/0/image", Value: "new-image"},
+			},
+			want:        &corev1.Pod{},
+			errorString: ptr.To("apply pod patch: Unexpected kind: invalid"),
+		},
 		"replace-image": {
 			modelPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/modelcontroller/patch_test.go
+++ b/internal/modelcontroller/patch_test.go
@@ -1,0 +1,85 @@
+package modelcontroller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/substratusai/kubeai/internal/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func Test_patchPod(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		modelPod *corev1.Pod
+		patches  []config.Patch
+		want     *corev1.Pod
+	}{
+		"replace-image": {
+			modelPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "test-image",
+						},
+					},
+				},
+			},
+			patches: []config.Patch{
+				{Op: "replace", Path: "/spec/containers/0/image", Value: "new-image"},
+			},
+			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "new-image",
+						},
+					},
+				},
+			},
+		},
+		"add-preemption-policy": {
+			modelPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Spec: corev1.PodSpec{},
+			},
+			patches: []config.Patch{
+				{Op: "add", Path: "/spec/preemptionPolicy", Value: "Never"},
+			},
+			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Spec: corev1.PodSpec{
+					PreemptionPolicy: ptr.To(corev1.PreemptNever),
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := patchPod(c.patches, c.modelPod)
+			require.NoError(t, err)
+			require.Equal(t, c.want, c.modelPod, "expected pod to be patched correctly")
+		})
+	}
+}

--- a/internal/modelcontroller/patch_test.go
+++ b/internal/modelcontroller/patch_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/substratusai/kubeai/internal/config"
+	"github.com/substratusai/kubeai/internal/k8sutils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -13,24 +14,30 @@ import (
 func Test_applyJSONPatchToPod(t *testing.T) {
 	t.Parallel()
 
+	emptyPod := &corev1.Pod{}
+	emptyPodHash := k8sutils.PodHash(emptyPod.Spec)
+
 	cases := map[string]struct {
-		modelPod    *corev1.Pod
-		patches     []config.JSONPatch
-		want        *corev1.Pod
-		errorString *string
+		modelPod     *corev1.Pod
+		patches      []config.JSONPatch
+		want         *corev1.Pod
+		errorString  *string
+		expectedHash *string
 	}{
 		"no-patch": {
-			modelPod: &corev1.Pod{},
-			patches:  nil,
-			want:     &corev1.Pod{},
+			modelPod:     emptyPod,
+			patches:      nil,
+			want:         emptyPod,
+			expectedHash: ptr.To(emptyPodHash), // default hash
 		},
 		"error-patch": {
-			modelPod: &corev1.Pod{},
+			modelPod: emptyPod,
 			patches: []config.JSONPatch{
 				{Op: "invalid", Path: "/spec/containers/0/image", Value: "new-image"},
 			},
-			want:        &corev1.Pod{},
-			errorString: ptr.To("apply pod patch: Unexpected kind: invalid"),
+			want:         emptyPod,
+			expectedHash: ptr.To(emptyPodHash), // since the patch failed it should not change the hash
+			errorString:  ptr.To("apply pod patch: Unexpected kind: invalid"),
 		},
 		"replace-image": {
 			modelPod: &corev1.Pod{
@@ -91,11 +98,17 @@ func Test_applyJSONPatchToPod(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			gotHash := k8sutils.PodHash(c.modelPod.Spec)
+
 			err := applyJSONPatchToPod(c.patches, c.modelPod)
 			if c.errorString != nil {
 				require.ErrorContains(t, err, *c.errorString)
 			} else {
 				require.NoError(t, err)
+			}
+
+			if c.expectedHash != nil {
+				require.Equal(t, *c.expectedHash, gotHash, "expected pod hash to be %s", *c.expectedHash)
 			}
 
 			require.Equal(t, c.want, c.modelPod, "expected pod to be patched correctly")

--- a/internal/modelcontroller/patch_test.go
+++ b/internal/modelcontroller/patch_test.go
@@ -33,7 +33,7 @@ func Test_patchPod(t *testing.T) {
 					},
 				},
 			},
-			patches: []config.Patch{
+			patches: []config.JSONPatch{
 				{Op: "replace", Path: "/spec/containers/0/image", Value: "new-image"},
 			},
 			want: &corev1.Pod{
@@ -59,7 +59,7 @@ func Test_patchPod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{},
 			},
-			patches: []config.Patch{
+			patches: []config.JSONPatch{
 				{Op: "add", Path: "/spec/preemptionPolicy", Value: "Never"},
 			},
 			want: &corev1.Pod{

--- a/internal/modelcontroller/pod_plan.go
+++ b/internal/modelcontroller/pod_plan.go
@@ -37,6 +37,8 @@ func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubea
 	default:
 		podForModel = r.vLLMPodForModel(model, modelConfig)
 	}
+
+	r.patchPod(podForModel)
 	expectedHash := k8sutils.PodHash(podForModel.Spec)
 	podForModel.GenerateName = fmt.Sprintf("model-%s-%s-", model.Name, expectedHash)
 	k8sutils.SetLabel(podForModel, kubeaiv1.PodHashLabel, expectedHash)

--- a/internal/modelcontroller/pod_plan.go
+++ b/internal/modelcontroller/pod_plan.go
@@ -25,9 +25,8 @@ import (
 // - Adds a surge Pod
 // - Recreates any out-of-date Pod that is not Ready immediately
 // - Waits for all Pods to be Ready before recreating any out-of-date Pods that are Ready
-func (r *ModelReconciler) calculatePodPlan(ctx context.Context, allPods *corev1.PodList, model *kubeaiv1.Model, modelConfig ModelConfig) *podPlan {
+func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubeaiv1.Model, modelConfig ModelConfig) (*podPlan, error) {
 	var podForModel *corev1.Pod
-	var log = log.FromContext(ctx)
 
 	switch model.Spec.Engine {
 	case kubeaiv1.OLlamaEngine:
@@ -41,7 +40,7 @@ func (r *ModelReconciler) calculatePodPlan(ctx context.Context, allPods *corev1.
 	}
 
 	if err := applyJSONPatchToPod(r.ModelServerPods.JSONPatches, podForModel); err != nil {
-		log.Error(err, "JSONPatches ignored as they failed to apply to Pod")
+		return nil, err
 	}
 
 	expectedHash := k8sutils.PodHash(podForModel.Spec)
@@ -153,7 +152,7 @@ func (r *ModelReconciler) calculatePodPlan(ctx context.Context, allPods *corev1.
 		toDelete: toDelete,
 		toRemain: toRemain,
 		details:  details,
-	}
+	}, nil
 }
 
 type podPlan struct {

--- a/internal/modelcontroller/pod_plan.go
+++ b/internal/modelcontroller/pod_plan.go
@@ -38,7 +38,7 @@ func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubea
 		podForModel = r.vLLMPodForModel(model, modelConfig)
 	}
 
-	r.patchPod(podForModel)
+	patchPod(r.ModelServerPods.ModelPodPatches, podForModel)
 	expectedHash := k8sutils.PodHash(podForModel.Spec)
 	podForModel.GenerateName = fmt.Sprintf("model-%s-%s-", model.Name, expectedHash)
 	k8sutils.SetLabel(podForModel, kubeaiv1.PodHashLabel, expectedHash)

--- a/internal/modelcontroller/pod_plan_test.go
+++ b/internal/modelcontroller/pod_plan_test.go
@@ -169,7 +169,8 @@ func Test_calculatePodPlan(t *testing.T) {
 			if c.jsonPatches != nil {
 				r.ModelServerPods.JSONPatches = c.jsonPatches
 			}
-			plan := r.calculatePodPlan(t.Context(), &corev1.PodList{Items: c.pods}, model, modelConfig)
+			plan, err := r.calculatePodPlan(&corev1.PodList{Items: c.pods}, model, modelConfig)
+			require.NoError(t, err)
 			detailsCSV := strings.Join(plan.details, ", ")
 			require.Lenf(t, plan.toCreate, c.wantNCreations, "Unexpected creation count, details: %v", detailsCSV)
 			var deletionNames []string

--- a/internal/modelcontroller/pod_plan_test.go
+++ b/internal/modelcontroller/pod_plan_test.go
@@ -154,7 +154,7 @@ func Test_calculatePodPlan(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			plan := r.calculatePodPlan(&corev1.PodList{Items: c.pods}, model, modelConfig)
+			plan := r.calculatePodPlan(t.Context(), &corev1.PodList{Items: c.pods}, model, modelConfig)
 			detailsCSV := strings.Join(plan.details, ", ")
 			require.Lenf(t, plan.toCreate, c.wantNCreations, "Unexpected creation count, details: %v", detailsCSV)
 			var deletionNames []string

--- a/internal/modelcontroller/pod_plan_test.go
+++ b/internal/modelcontroller/pod_plan_test.go
@@ -109,16 +109,6 @@ func Test_calculatePodPlan(t *testing.T) {
 			wantNCreations: 2,
 		},
 		{
-			name: "ignore json patch failure",
-			pods: []corev1.Pod{
-				testPod("up-to-date-1", expectedHash, ready),
-			},
-			wantNCreations: 2,
-			jsonPatches: []config.JSONPatch{
-				{Op: "invalid", Path: "/spec/containers/0/image", Value: "new-image"},
-			},
-		},
-		{
 			name: "scale down",
 			pods: []corev1.Pod{
 				testPod("ready-up-to-date-1", expectedHash, ready),


### PR DESCRIPTION
Adds support for applying arbitrary JSON 6902 / JSONPatch support for model server pods.

For example, our clusters have a number of mutating webhooks which inject special priority class names and various pre-emption policies based on various labels, etc. This gives operators a way to set the pod templates up which can work in constrained clusters (i.e. those with OPA gatekeeper constraints).

```yaml
modelServerPods:
  - op: add
    path: /spec/priorityClassName
    value: gpu

```