### PR TITLE
allow s3 model urls without cache profile

### DIFF
--- a/api/k8s/v1/model_types.go
+++ b/api/k8s/v1/model_types.go
@@ -24,7 +24,6 @@ import (
 
 // ModelSpec defines the desired state of Model.
 // +kubebuilder:validation:XValidation:rule="!has(self.cacheProfile) || self.url.startsWith(\"hf://\") || self.url.startsWith(\"s3://\") || self.url.startsWith(\"gs://\") || self.url.startsWith(\"oss://\")", message="cacheProfile is only supported with urls of format \"hf://...\", \"s3://...\", \"gs://...\", or \"oss://...\" at the moment."
-// +kubebuilder:validation:XValidation:rule="!self.url.startsWith(\"s3://\") || has(self.cacheProfile)", message="urls of format \"s3://...\" only supported when using a cacheProfile"
 // +kubebuilder:validation:XValidation:rule="!self.url.startsWith(\"gs://\") || has(self.cacheProfile)", message="urls of format \"gs://...\" only supported when using a cacheProfile"
 // +kubebuilder:validation:XValidation:rule="!self.url.startsWith(\"oss://\") || has(self.cacheProfile)", message="urls of format \"oss://...\" only supported when using a cacheProfile"
 // +kubebuilder:validation:XValidation:rule="!has(self.maxReplicas) || self.minReplicas <= self.maxReplicas", message="minReplicas should be less than or equal to maxReplicas."

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -261,8 +261,6 @@ spec:
                 "s3://...", "gs://...", or "oss://..." at the moment.
               rule: '!has(self.cacheProfile) || self.url.startsWith("hf://") || self.url.startsWith("s3://")
                 || self.url.startsWith("gs://") || self.url.startsWith("oss://")'
-            - message: urls of format "s3://..." only supported when using a cacheProfile
-              rule: '!self.url.startsWith("s3://") || has(self.cacheProfile)'
             - message: urls of format "gs://..." only supported when using a cacheProfile
               rule: '!self.url.startsWith("gs://") || has(self.cacheProfile)'
             - message: urls of format "oss://..." only supported when using a cacheProfile

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -261,6 +261,8 @@ spec:
                 "s3://...", "gs://...", or "oss://..." at the moment.
               rule: '!has(self.cacheProfile) || self.url.startsWith("hf://") || self.url.startsWith("s3://")
                 || self.url.startsWith("gs://") || self.url.startsWith("oss://")'
+            - message: urls of format "s3://..." only supported when using a cacheProfile
+              rule: '!self.url.startsWith("s3://") || has(self.cacheProfile)'
             - message: urls of format "gs://..." only supported when using a cacheProfile
               rule: '!self.url.startsWith("gs://") || has(self.cacheProfile)'
             - message: urls of format "oss://..." only supported when using a cacheProfile

--- a/internal/modelcontroller/engine_vllm.go
+++ b/internal/modelcontroller/engine_vllm.go
@@ -18,10 +18,12 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 	}
 
 	vllmModelFlag := c.Source.url.ref
+	useRunaiStreamer := false
 	if m.Spec.CacheProfile != "" {
 		vllmModelFlag = modelCacheDir(m)
 	} else if c.Source.url.scheme == "s3" {
 		vllmModelFlag = c.Source.url.original
+		useRunaiStreamer = true
 	}
 	// The vllmModelFlag can be safely overridden because validation logic ensures
 	// that a model with PVC source and cacheProfile won't be admitted.
@@ -32,6 +34,9 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 	args := []string{
 		"--model=" + vllmModelFlag,
 		"--served-model-name=" + m.Name,
+	}
+	if useRunaiStreamer {
+		args = append(args, "--load-format=runai_streamer")
 	}
 	args = append(args, m.Spec.Args...)
 

--- a/internal/modelcontroller/engine_vllm.go
+++ b/internal/modelcontroller/engine_vllm.go
@@ -20,6 +20,8 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 	vllmModelFlag := c.Source.url.ref
 	if m.Spec.CacheProfile != "" {
 		vllmModelFlag = modelCacheDir(m)
+	} else if c.Source.url.scheme == "s3" {
+		vllmModelFlag = c.Source.url.original
 	}
 	// The vllmModelFlag can be safely overridden because validation logic ensures
 	// that a model with PVC source and cacheProfile won't be admitted.

--- a/test/integration/model_validation_test.go
+++ b/test/integration/model_validation_test.go
@@ -240,14 +240,14 @@ func TestModelValidation(t *testing.T) {
 		},
 		{
 			model: v1.Model{
-				ObjectMeta: metadata("s3-url-without-cache-profile-invalid"),
+				ObjectMeta: metadata("s3-url-without-cache-profile-valid"),
 				Spec: v1.ModelSpec{
 					URL:      "s3://test-bucket/test-path",
 					Engine:   "VLLM",
 					Features: []v1.ModelFeature{},
 				},
 			},
-			expValid: false,
+			expValid: true,
 		},
 		{
 			model: v1.Model{


### PR DESCRIPTION
There are a few small issues that prevent loading llms via s3 without using a cache profile:
- remove rule enforcing s3 only with cache profile
- if no cache profile and scheme is s3 then use original url and not a pvc
