### PR TITLE
Support multiple Kubeai installation in different namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,12 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen yq
 	# Generate CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) crd webhook paths="./..." output:crd:artifacts:config=charts/kubeai/templates/crds/
+	$(CONTROLLER_GEN) crd webhook paths="./..." output:crd:artifacts:config=manifests/crds/
+
+	# Generate CustomResourceDefinition for helm chart
+	echo '{{-  if .Values.crds.enabled -}}' > charts/kubeai/templates/crds/kubeai.org_models.yaml
+	cat manifests/crds/kubeai.org_models.yaml >> charts/kubeai/templates/crds/kubeai.org_models.yaml
+	echo '{{-  end }}' >> charts/kubeai/templates/crds/kubeai.org_models.yaml
 
 	# Generate model manifests.
 	rm -f ./manifests/models/*

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -1,3 +1,4 @@
+{{-  if .Values.crds.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -364,3 +365,4 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas.all
       status: {}
+{{- end }}

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -1,6 +1,8 @@
 # Default values for kubeai.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+crds:
+  enabled: true
 
 secrets:
   alibaba:

--- a/manifests/crds/kubeai.org_models.yaml
+++ b/manifests/crds/kubeai.org_models.yaml
@@ -1,4 +1,3 @@
-{{-  if .Values.crds.enabled -}}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -365,4 +364,3 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas.all
       status: {}
-{{-  end }}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -80,7 +80,7 @@ func TestMain(m *testing.M) {
 
 	// Setup Kubernetes environment.
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{"../../charts/kubeai/templates/crds"},
+		CRDDirectoryPaths:     []string{"../../manifests/crds"},
 		ErrorIfCRDPathMissing: true,
 	}
 	var err error


### PR DESCRIPTION
At the moment it is not possible to install multiple Kubeai instances in the same cluster and in different namespaces due to the way helm handles CRDs.

In this PR I added the _crds.enabled_ value to control the installation of CRDs.

An alternative would be to move the "crds" folder to the root of the Chart and use the helm flag --skip-crds to disable its installation. However, this involves having to manually manage the CRDs update.