### PR TITLE
Add Minimum Load Threshold Setting

### DIFF
--- a/api/k8s/v1/model_types.go
+++ b/api/k8s/v1/model_types.go
@@ -199,6 +199,9 @@ type PrefixHash struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=100
 	PrefixCharLength int `json:"prefixCharLength,omitempty"`
+	// MinLoadThreshold is the minimum number of requests an endpoint must receive to be considered overloaded.
+	// +kubebuilder:validation:Optional
+	MinLoadThreshold *int `json:"minLoadThreshold,omitempty"`
 }
 
 // File represents a file to be mounted in the model pod.

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -200,6 +200,10 @@ spec:
                           a widely accepted value for the Consistent Hashing with Bounded Loads algorithm.
                         minimum: 100
                         type: integer
+                      minLoadThreshold:
+                        description: MinLoadThreshold is the minimum number of requests
+                          an endpoint must receive to be considered overloaded.
+                        type: integer
                       prefixCharLength:
                         default: 100
                         description: PrefixCharLength is the number of characters

--- a/internal/loadbalancer/group.go
+++ b/internal/loadbalancer/group.go
@@ -65,9 +65,13 @@ func (g *group) getBestAddr(ctx context.Context, req *apiutils.Request, awaitCha
 
 	var ep endpoint
 	var found bool
+	minThresh := 0.0
 	switch req.LoadBalancing.Strategy {
 	case v1.PrefixHashStrategy:
-		ep, found = g.chwblGetAddr(req.Adapter+req.Prefix, float64(req.LoadBalancing.PrefixHash.MeanLoadPercentage)/100, req.Adapter)
+		if req.LoadBalancing.PrefixHash.MinLoadThreshold != nil {
+			minThresh = float64(*req.LoadBalancing.PrefixHash.MinLoadThreshold)
+		}
+		ep, found = g.chwblGetAddr(req.Adapter+req.Prefix, float64(req.LoadBalancing.PrefixHash.MeanLoadPercentage)/100, req.Adapter, minThresh)
 	case v1.LeastLoadStrategy:
 		ep, found = g.getAddrLeastLoad(req.Adapter)
 	default:


### PR DESCRIPTION
We have been using KubeAI to load balance across hundreds of vLLM instances using the PrefixHash load balancing strategy. We've encountered an edge case that occurs when two conditions are met, 1). you have hundreds of instances running and 2). your traffic is such that a large percentage of traffic (say 25%) has the same prefix. 

This leads to issues where the load threshold calculated is a very small number as traffic ramps up due to the large number of instances in the denominator. Due to this low load threshold no instances appear ready for the next request. This would be acceptable if each request had a unique prefix as the default instance the request is assigned to would be more or less random and distribute load relatively evenly. However, when some prefixes are very common, those requests are all routed to the same instance as the traffic ramps up. 

A potential solution to this situation is to define a setting, minimum load threshold, which can be set to essentially override the calculated threshold. This would allow requests with the common prefixes to be distributed more evenly to other instances without encountering situations where the high number of instances causes all instances to appear to be exceeding the load threshold and thus default to the default instance. 

Would love to get your feedback on this issue and potential solution!