### PR TITLE
fix: remove default runAsUser value from chart values

### DIFF
--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -70,7 +70,7 @@ modelServerPods:
   # Security Context for the model pods
   # Needed for OpenShift
   securityContext:
-    runAsUser: 0
+    # runAsUser: 0
     readOnlyRootFilesystem: false
     allowPrivilegeEscalation: false
     capabilities:
@@ -245,7 +245,7 @@ open-webui:
   # Security Context for the openwebui pod
   # Needed for OpenShift
   containerSecurityContext:
-    runAsUser: 0
+    # runAsUser: 0
     readOnlyRootFilesystem: false
     allowPrivilegeEscalation: false
     capabilities:


### PR DESCRIPTION
Removed the default value of runAsUser (now setted as 0), which does not allow easy execution of runtimes in namespaces that have the standard pod policy configured to restricted.