### PR TITLE
fix: exclude terminating pods from rollout plan calculation

### DIFF
--- a/internal/modelcontroller/pod_plan.go
+++ b/internal/modelcontroller/pod_plan.go
@@ -57,6 +57,15 @@ func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubea
 		return p.Namespace + "/" + p.Name
 	}
 
+	// Skip terminating pods to avoid inflating observedReplicas during rollouts.
+	nonTerminating := allPods.Items[:0]
+	for _, p := range allPods.Items {
+		if p.DeletionTimestamp == nil {
+			nonTerminating = append(nonTerminating, p)
+		}
+	}
+	allPods.Items = nonTerminating
+
 	sortPodsByDeletionOrder(allPods.Items, expectedHash)
 
 	for _, p := range allPods.Items {

--- a/internal/modelcontroller/pod_plan_test.go
+++ b/internal/modelcontroller/pod_plan_test.go
@@ -151,6 +151,21 @@ func Test_calculatePodPlan(t *testing.T) {
 			wantNCreations: 0,
 			wantDeletions:  []string{"ready-out-of-date-3"},
 		},
+		{
+			name: "terminating pods excluded from plan calculation",
+			pods: []corev1.Pod{
+				testPod("ready-new-1", expectedHash, ready),
+				testPod("ready-new-2", expectedHash, ready),
+				func() corev1.Pod {
+					p := testPod("terminating-old", "old-hash", unready)
+					now := metav1.Now()
+					p.DeletionTimestamp = &now
+					return p
+				}(),
+			},
+			wantNCreations: 1,   // still needs 1 more pod to reach replicas=3
+			wantDeletions:  nil, // terminating pod should NOT be re-deleted
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Problem

During a rolling update, users see multiple pods created and immediately terminated before one stabilizes (#442).

## Root Cause

`calculatePodPlan` counted all pods including those with `DeletionTimestamp` set. This inflates `observedReplicas`: a terminating old pod + a new replacement pod push the count above `desiredReplicas`, triggering deletion of the replacement. The out-of-date loop then recreates it, producing a tight create-delete loop until Kubernetes removes the terminating pod from the informer cache.

## Fix

Filter out terminating pods at the start of `calculatePodPlan` before any replica counting or rollout decisions. Status reporting in the controller continues to use the full pod list for accurate counts.

## Testing

- Added unit test case: terminating pod with old hash present alongside two ready pods — verifies no deletion is triggered and the missing replica is created correctly.

Fixes #442