### PR TITLE
Add support to load models as OCI images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Install kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,7 @@ jobs:
         - "model-files"
         - "s3-model"
         - "lora-adapter"
+        - "oci-model"
     steps:
       - name: Aggressive cleanup
         if: matrix.testcase == 's3-model'

--- a/api/k8s/v1/model_types.go
+++ b/api/k8s/v1/model_types.go
@@ -42,6 +42,7 @@ type ModelSpec struct {
 	// "hf://<repo>/<model>"
 	// "pvc://<pvcName>"
 	// "pvc://<pvcName>/<pvcSubpath>"
+	// "oci://<registry>/<repository>:<tag>"
 	// "gs://<bucket>/<path>" (only with cacheProfile)
 	// "oss://<bucket>/<path>" (only with cacheProfile)
 	// "s3://<bucket>/<path>" (only with cacheProfile)
@@ -51,7 +52,7 @@ type ModelSpec struct {
 	// "ollama://<model>"
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self.startsWith(\"hf://\") || self.startsWith(\"pvc://\") || self.startsWith(\"ollama://\") || self.startsWith(\"s3://\") || self.startsWith(\"gs://\") || self.startsWith(\"oss://\")", message="url must start with \"hf://\", \"pvc://\", \"ollama://\", \"s3://\", \"gs://\", or \"oss://\" and not be empty."
+	// +kubebuilder:validation:XValidation:rule="self.startsWith(\"oci://\") || self.startsWith(\"hf://\") || self.startsWith(\"pvc://\") || self.startsWith(\"ollama://\") || self.startsWith(\"s3://\") || self.startsWith(\"gs://\") || self.startsWith(\"oss://\")", message="url must start with \"hf://\", \"pvc://\", \"ollama://\", \"s3://\", \"gs://\", or \"oss://\" and not be empty."
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]+):\/\/([a-zA-Z0-9._:/-]+)(\?.*)?$`
 	URL string `json:"url"`
 

--- a/api/k8s/v1/model_types.go
+++ b/api/k8s/v1/model_types.go
@@ -52,7 +52,7 @@ type ModelSpec struct {
 	// "ollama://<model>"
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self.startsWith(\"oci://\") || self.startsWith(\"hf://\") || self.startsWith(\"pvc://\") || self.startsWith(\"ollama://\") || self.startsWith(\"s3://\") || self.startsWith(\"gs://\") || self.startsWith(\"oss://\")", message="url must start with \"hf://\", \"pvc://\", \"ollama://\", \"s3://\", \"gs://\", or \"oss://\" and not be empty."
+	// +kubebuilder:validation:XValidation:rule="self.startsWith(\"oci://\") || self.startsWith(\"hf://\") || self.startsWith(\"pvc://\") || self.startsWith(\"ollama://\") || self.startsWith(\"s3://\") || self.startsWith(\"gs://\") || self.startsWith(\"oss://\")", message="url must start with \"oci://\", \"hf://\", \"pvc://\", \"ollama://\", \"s3://\", \"gs://\", or \"oss://\" and not be empty."
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]+):\/\/([a-zA-Z0-9._:/-]+)(\?.*)?$`
 	URL string `json:"url"`
 

--- a/charts/kubeai/templates/configmap.yaml
+++ b/charts/kubeai/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
       aws: {{ include "kubeai.awsSecretName" . }}
       gcp: {{ include "kubeai.gcpSecretName" . }}
       huggingface: {{ include "kubeai.huggingfaceSecretName" . }}
+      oci: {{ .Values.secrets.oci.name }}
     resourceProfiles:
       {{- .Values.resourceProfiles | toYaml | nindent 6 }}
     cacheProfiles:

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -288,6 +288,7 @@ spec:
                   "hf://<repo>/<model>"
                   "pvc://<pvcName>"
                   "pvc://<pvcName>/<pvcSubpath>"
+                  "oci://<registry>/<repository>:<tag>"
                   "gs://<bucket>/<path>" (only with cacheProfile)
                   "oss://<bucket>/<path>" (only with cacheProfile)
                   "s3://<bucket>/<path>" (only with cacheProfile)
@@ -300,8 +301,9 @@ spec:
                 x-kubernetes-validations:
                 - message: url must start with "hf://", "pvc://", "ollama://", "s3://",
                     "gs://", or "oss://" and not be empty.
-                  rule: self.startsWith("hf://") || self.startsWith("pvc://") || self.startsWith("ollama://")
-                    || self.startsWith("s3://") || self.startsWith("gs://") || self.startsWith("oss://")
+                  rule: self.startsWith("oci://") || self.startsWith("hf://") || self.startsWith("pvc://")
+                    || self.startsWith("ollama://") || self.startsWith("s3://") ||
+                    self.startsWith("gs://") || self.startsWith("oss://")
             required:
             - engine
             - features

--- a/charts/kubeai/templates/crds/kubeai.org_models.yaml
+++ b/charts/kubeai/templates/crds/kubeai.org_models.yaml
@@ -299,8 +299,8 @@ spec:
                 pattern: ^([a-z0-9]+):\/\/([a-zA-Z0-9._:/-]+)(\?.*)?$
                 type: string
                 x-kubernetes-validations:
-                - message: url must start with "hf://", "pvc://", "ollama://", "s3://",
-                    "gs://", or "oss://" and not be empty.
+                - message: url must start with "oci://", "hf://", "pvc://", "ollama://",
+                    "s3://", "gs://", or "oss://" and not be empty.
                   rule: self.startsWith("oci://") || self.startsWith("hf://") || self.startsWith("pvc://")
                     || self.startsWith("ollama://") || self.startsWith("s3://") ||
                     self.startsWith("gs://") || self.startsWith("oss://")

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -35,6 +35,9 @@ secrets:
     # If not set, and create is true, the name is generated using the fullname template.
     # The token value is pulled from the key, "token".
     name: ""
+  oci:
+    # The name of the secret to use to authenticate to OCI registries.
+    name: ""
 
 modelServers:
   VLLM:

--- a/docs/how-to/load-models-from-oci.md
+++ b/docs/how-to/load-models-from-oci.md
@@ -1,0 +1,82 @@
+# Load Models from OCI Images
+
+You can package your models into OCI images and let KubeAI use them for serving.
+KubeAI mounts the image contents directly into the model server Pod using a Kubernetes
+[image volume](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/),
+so the model files are available without a separate download step.
+
+> **Note:** The container runtime determines what kind of OCI references are supported:
+> - When **containerd** is used as the container runtime, only **OCI images** are supported.
+> - When **CRI-O** is used as the container runtime, both **OCI images** and **OCI artifacts** are supported.
+>
+> Image volumes also require a sufficiently recent Kubernetes version with the
+> `ImageVolume` feature enabled on the cluster.
+
+## vLLM
+
+For vLLM, use the following URL format:
+```yaml
+url: oci://$REGISTRY/$REPOSITORY:$TAG    # Loads the model from the OCI image
+```
+
+For example:
+```yaml
+url: oci://docker.io/myorg/llama-3.1-8b:latest
+```
+
+The contents of the image are mounted at `/model` inside the model server Pod and vLLM is
+configured to load the model from that path.
+
+### Image requirements
+
+The OCI image must contain the model files (the same layout vLLM expects when loading a model
+from a local directory) at the root of the image filesystem. KubeAI mounts the image read-only,
+so the model files must already be present in the image before creating the Model resource.
+
+## Authentication for private registries
+
+When pulling from a private registry, create a Kubernetes image pull `Secret` and configure
+KubeAI to use it.
+
+1. Create the pull secret:
+
+   ```bash
+   kubectl create secret docker-registry oci-pull-secret \
+     --docker-server=$REGISTRY \
+     --docker-username=$USERNAME \
+     --docker-password=$PASSWORD
+   ```
+
+2. Reference the secret in your KubeAI installation:
+
+   ```bash
+   helm upgrade --install kubeai kubeai/kubeai \
+       --set secrets.oci.name=oci-pull-secret \
+       ...
+   ```
+
+   KubeAI adds this secret to the model server Pod's `imagePullSecrets` so the image volume can
+   be pulled from the private registry.
+
+**NOTE:** KubeAI does not automatically react to updates to credentials. You will need to
+manually delete and allow KubeAI to recreate any failed Jobs/Pods that required credentials.
+
+### Example: Loading OPT-125m from an OCI image
+
+1. Push an OCI image that contains the model files to a registry your cluster can access.
+
+2. Create a Model to load from the OCI image:
+
+   ```yaml
+   apiVersion: kubeai.org/v1
+   kind: Model
+   metadata:
+     name: opt-125m-cpu
+   spec:
+     features: [TextGeneration]
+     owner: facebook
+     url: oci://docker.io/myorg/facebook-opt-125m:oci-image
+     engine: VLLM
+     resourceProfile: cpu:1
+     minReplicas: 1
+   ```

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -159,6 +159,7 @@ type SecretNames struct {
 	AWS         string `json:"aws" required:"true"`
 	GCP         string `json:"gcp" required:"true"`
 	Huggingface string `json:"huggingface" required:"true"`
+	OCI         string `json:"oci" required:"false"`
 }
 
 type Messaging struct {

--- a/internal/modelcontroller/engine_vllm.go
+++ b/internal/modelcontroller/engine_vllm.go
@@ -27,7 +27,7 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 	}
 	// The vllmModelFlag can be safely overridden because validation logic ensures
 	// that a model with PVC source and cacheProfile won't be admitted.
-	if c.Source.url.scheme == "pvc" {
+	if c.Source.url.scheme == "pvc" || c.Source.url.scheme == "oci" {
 		vllmModelFlag = "/model"
 	}
 

--- a/internal/modelcontroller/model_source.go
+++ b/internal/modelcontroller/model_source.go
@@ -36,6 +36,8 @@ func (r *ModelReconciler) parseModelSource(urlStr string) (modelSource, error) {
 		src.modelSourcePodAdditions = r.authForHuggingfaceHub()
 	case u.scheme == "pvc":
 		src.modelSourcePodAdditions = r.pvcPodAdditions(u)
+	case u.scheme == "oci":
+		src.modelSourcePodAdditions = r.ociPodAdditions(u)
 	default:
 		src.modelSourcePodAdditions = &modelSourcePodAdditions{}
 	}
@@ -43,10 +45,11 @@ func (r *ModelReconciler) parseModelSource(urlStr string) (modelSource, error) {
 }
 
 type modelSourcePodAdditions struct {
-	envFrom      []corev1.EnvFromSource
-	env          []corev1.EnvVar
-	volumes      []corev1.Volume
-	volumeMounts []corev1.VolumeMount
+	envFrom          []corev1.EnvFromSource
+	env              []corev1.EnvVar
+	volumes          []corev1.Volume
+	volumeMounts     []corev1.VolumeMount
+	imagePullSecrets []corev1.LocalObjectReference
 }
 
 func (c *modelSourcePodAdditions) append(other *modelSourcePodAdditions) {
@@ -54,6 +57,7 @@ func (c *modelSourcePodAdditions) append(other *modelSourcePodAdditions) {
 	c.env = append(c.env, other.env...)
 	c.volumes = append(c.volumes, other.volumes...)
 	c.volumeMounts = append(c.volumeMounts, other.volumeMounts...)
+	c.imagePullSecrets = append(c.imagePullSecrets, other.imagePullSecrets...)
 }
 
 func (c *modelSourcePodAdditions) applyToPodSpec(spec *corev1.PodSpec, containerIndex int) {
@@ -61,6 +65,7 @@ func (c *modelSourcePodAdditions) applyToPodSpec(spec *corev1.PodSpec, container
 	spec.Containers[containerIndex].Env = append(spec.Containers[containerIndex].Env, c.env...)
 	spec.Volumes = append(spec.Volumes, c.volumes...)
 	spec.Containers[containerIndex].VolumeMounts = append(spec.Containers[containerIndex].VolumeMounts, c.volumeMounts...)
+	spec.ImagePullSecrets = append(spec.ImagePullSecrets, c.imagePullSecrets...)
 }
 
 func (r *ModelReconciler) modelAuthCredentialsForAllSources() *modelSourcePodAdditions {
@@ -221,6 +226,34 @@ func (r *ModelReconciler) pvcPodAdditions(url modelURL) *modelSourcePodAdditions
 				Name:      volumeName,
 				MountPath: "/model",
 				SubPath:   path,
+			},
+		},
+	}
+}
+
+func (r *ModelReconciler) ociPodAdditions(url modelURL) *modelSourcePodAdditions {
+	volumeName := "model"
+	return &modelSourcePodAdditions{
+		volumes: []corev1.Volume{
+			{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference:  url.name + "/" + url.path,
+						PullPolicy: corev1.PullIfNotPresent,
+					},
+				},
+			},
+		},
+		volumeMounts: []corev1.VolumeMount{
+			{
+				Name:      volumeName,
+				MountPath: "/model",
+			},
+		},
+		imagePullSecrets: []corev1.LocalObjectReference{
+			{
+				Name: r.SecretNames.OCI,
 			},
 		},
 	}

--- a/manifests/crds/kubeai.org_models.yaml
+++ b/manifests/crds/kubeai.org_models.yaml
@@ -298,8 +298,8 @@ spec:
                 pattern: ^([a-z0-9]+):\/\/([a-zA-Z0-9._:/-]+)(\?.*)?$
                 type: string
                 x-kubernetes-validations:
-                - message: url must start with "hf://", "pvc://", "ollama://", "s3://",
-                    "gs://", or "oss://" and not be empty.
+                - message: url must start with "oci://", "hf://", "pvc://", "ollama://",
+                    "s3://", "gs://", or "oss://" and not be empty.
                   rule: self.startsWith("oci://") || self.startsWith("hf://") || self.startsWith("pvc://")
                     || self.startsWith("ollama://") || self.startsWith("s3://") ||
                     self.startsWith("gs://") || self.startsWith("oss://")

--- a/manifests/crds/kubeai.org_models.yaml
+++ b/manifests/crds/kubeai.org_models.yaml
@@ -287,6 +287,7 @@ spec:
                   "hf://<repo>/<model>"
                   "pvc://<pvcName>"
                   "pvc://<pvcName>/<pvcSubpath>"
+                  "oci://<registry>/<repository>:<tag>"
                   "gs://<bucket>/<path>" (only with cacheProfile)
                   "oss://<bucket>/<path>" (only with cacheProfile)
                   "s3://<bucket>/<path>" (only with cacheProfile)
@@ -299,8 +300,9 @@ spec:
                 x-kubernetes-validations:
                 - message: url must start with "hf://", "pvc://", "ollama://", "s3://",
                     "gs://", or "oss://" and not be empty.
-                  rule: self.startsWith("hf://") || self.startsWith("pvc://") || self.startsWith("ollama://")
-                    || self.startsWith("s3://") || self.startsWith("gs://") || self.startsWith("oss://")
+                  rule: self.startsWith("oci://") || self.startsWith("hf://") || self.startsWith("pvc://")
+                    || self.startsWith("ollama://") || self.startsWith("s3://") ||
+                    self.startsWith("gs://") || self.startsWith("oss://")
             required:
             - engine
             - features

--- a/test/e2e/oci-model/model.yaml
+++ b/test/e2e/oci-model/model.yaml
@@ -1,0 +1,11 @@
+apiVersion: kubeai.org/v1
+kind: Model
+metadata:
+  name: opt-125m-cpu
+spec:
+  features: [TextGeneration]
+  owner: facebook
+  url: oci://ghcr.io/kubeai-project/facebook-opt-125m:oci-image
+  engine: VLLM
+  resourceProfile: cpu:1
+  minReplicas: 1

--- a/test/e2e/oci-model/skaffold.yaml
+++ b/test/e2e/oci-model/skaffold.yaml
@@ -1,0 +1,23 @@
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: oci-models
+# build:
+#   artifacts:
+#     - image: ghcr.io/kubeai-project/kubeai
+#   local:
+#     push: false
+deploy:
+  helm:
+    releases:
+      - name: kubeai
+        chartPath: ./charts/kubeai
+        valuesFiles:
+          - ./test/e2e/oci-model/values.yaml
+        skipBuildDependencies: true
+portForward:
+  - resourceType: service
+    resourceName: kubeai
+    namespace: default
+    port: 80
+    localPort: 8000

--- a/test/e2e/oci-model/test.sh
+++ b/test/e2e/oci-model/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source $REPO_DIR/test/e2e/common.sh
+
+model="opt-125m-cpu"
+
+kubectl apply -f $TEST_DIR/model.yaml
+kubectl wait --timeout=5m --for=jsonpath='{.status.replicas.ready}'=1 model/$model
+
+sleep 5
+
+# There are 1 replicas so send 10 requests to ensure that both replicas are used.
+for i in {1..5}; do
+  echo "Sending request $i"
+  curl http://localhost:8000/openai/v1/completions \
+    --max-time 600 \
+    -H "Content-Type: application/json" \
+    -d '{"model": "opt-125m-cpu", "prompt": "Who was the first president of the United States?", "max_tokens": 40}'
+done

--- a/test/e2e/oci-model/values.yaml
+++ b/test/e2e/oci-model/values.yaml
@@ -1,0 +1,19 @@
+open-webui:
+  enabled: false
+secrets:
+  oci:
+    name: "testsecret"
+cacheProfiles:
+  e2e-test-kind-pv:
+    sharedFilesystem:
+      persistentVolumeName: "kind-hostpath"
+modelServers:
+  VLLM:
+    images:
+      default: "ghcr.io/kubeai-project/vllm-cpu-test-env:v0.10.2"
+      cpu: "ghcr.io/kubeai-project/vllm-cpu-test-env:v0.10.2"
+image:
+  tag: "test"
+  # pullPolicy: Never
+modelLoading:
+  image: "ghcr.io/kubeai-project/kubeai-model-loader:test"


### PR DESCRIPTION
Introduce functionality to load models packaged as OCI images, allowing KubeAI to serve models directly from these images. This update includes necessary changes to the model specifications, validation rules, and authentication mechanisms for private registries. Documentation for using OCI images with KubeAI has also been added.

Fixes:  #660