### PR TITLE
feat: add support for /v1/responses

### DIFF
--- a/api/openai/v1/responses.go
+++ b/api/openai/v1/responses.go
@@ -1,0 +1,83 @@
+package v1
+
+import (
+	"fmt"
+
+	"github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// ResponsesInput is the input field of a Responses API request.
+// It can be a plain string or an array of input items.
+type ResponsesInput struct {
+	String string
+	Array  []ResponsesInputItem
+}
+
+func (r *ResponsesInput) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		r.String = s
+		return nil
+	}
+	var arr []ResponsesInputItem
+	if err := json.Unmarshal(data, &arr); err == nil {
+		r.Array = arr
+		return nil
+	}
+	return fmt.Errorf("input must be a string or an array of input items")
+}
+
+func (r ResponsesInput) MarshalJSON() ([]byte, error) {
+	if r.Array != nil {
+		return json.Marshal(r.Array)
+	}
+	return json.Marshal(r.String)
+}
+
+// ResponsesInputItem is a single item in a Responses API input array.
+type ResponsesInputItem struct {
+	Type    string              `json:"type,omitzero"`
+	Role    string              `json:"role,omitzero"`
+	Content *ChatMessageContent `json:"content,omitzero"`
+	Unknown jsontext.Value      `json:",unknown"`
+}
+
+// ResponsesRequest is the request body for POST /v1/responses.
+type ResponsesRequest struct {
+	Model              string            `json:"model"`
+	Input              ResponsesInput    `json:"input"`
+	Instructions       string            `json:"instructions,omitzero"`
+	PreviousResponseID string            `json:"previous_response_id,omitzero"`
+	MaxOutputTokens    *int              `json:"max_output_tokens,omitzero"`
+	Stream             bool              `json:"stream,omitzero"`
+	Temperature        *float32          `json:"temperature,omitzero"`
+	TopP               *float32          `json:"top_p,omitzero"`
+	User               string            `json:"user,omitzero"`
+	Metadata           map[string]string `json:"metadata,omitzero"`
+	Store              bool              `json:"store,omitzero"`
+	// Unknown fields are preserved to support backend-specific extensions.
+	Unknown jsontext.Value `json:",unknown"`
+}
+
+func (r *ResponsesRequest) GetModel() string  { return r.Model }
+func (r *ResponsesRequest) SetModel(m string) { r.Model = m }
+
+func (r *ResponsesRequest) Prefix(n int) string {
+	if r.Input.String != "" {
+		return firstNChars(r.Input.String, n)
+	}
+	for _, item := range r.Input.Array {
+		if item.Role == "user" && item.Content != nil {
+			if item.Content.String != "" {
+				return firstNChars(item.Content.String, n)
+			}
+			for _, part := range item.Content.Array {
+				if part.Type == ChatMessagePartTypeText {
+					return firstNChars(part.Text, n)
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/api/openai/v1/responses_test.go
+++ b/api/openai/v1/responses_test.go
@@ -1,0 +1,183 @@
+package v1_test
+
+import (
+	stdjson "encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/go-json-experiment/json"
+	v1 "github.com/kubeai-project/kubeai/api/openai/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponsesRequestPrefix(t *testing.T) {
+	cases := []struct {
+		input string
+		n     int
+		exp   string
+	}{
+		// String input
+		{`{"model":"m","input":""}`, 9, ""},
+		{`{"model":"m","input":"hello"}`, 0, ""},
+		{`{"model":"m","input":"hello"}`, 5, "hello"},
+		{`{"model":"m","input":"hello world"}`, 5, "hello"},
+		{`{"model":"m","input":"世界"}`, 1, "世"},
+		{`{"model":"m","input":"世界"}`, 2, "世界"},
+		{`{"model":"m","input":"世界"}`, 9, "世界"},
+		// Array input — user message
+		{`{"model":"m","input":[{"role":"user","content":"abc"}]}`, 9, "abc"},
+		{`{"model":"m","input":[{"role":"user","content":"abcdefghij"}]}`, 5, "abcde"},
+		// Array input — skips system, picks first user
+		{`{"model":"m","input":[{"role":"system","content":"sys"},{"role":"user","content":"usr"}]}`, 9, "usr"},
+		// Array input — no user message
+		{`{"model":"m","input":[{"role":"system","content":"sys"}]}`, 9, ""},
+		// Array input — multipart content, picks first text part
+		{fmt.Sprintf(`{"model":"m","input":[{"role":"user","content":[{"type":"text","text":"hi"},{"type":"image_url","image_url":{"url":"http://x"}}]}]}`), 9, "hi"},
+		// Empty array
+		{`{"model":"m","input":[]}`, 9, ""},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%q n=%d", c.input, c.n), func(t *testing.T) {
+			var req v1.ResponsesRequest
+			require.NoError(t, json.Unmarshal([]byte(c.input), &req))
+			require.Equal(t, c.exp, req.Prefix(c.n))
+		})
+	}
+}
+
+func TestResponsesRequest_JSON(t *testing.T) {
+	cases := []struct {
+		name          string
+		inputJSON     string
+		roundTripJSON string
+		req           *v1.ResponsesRequest
+	}{
+		{
+			name:      "string input",
+			inputJSON: `{"model":"gpt-4o","input":"Tell me a joke"}`,
+			req: &v1.ResponsesRequest{
+				Model: "gpt-4o",
+				Input: v1.ResponsesInput{String: "Tell me a joke"},
+			},
+		},
+		{
+			name:      "array input with single user message",
+			inputJSON: `{"model":"gpt-4o","input":[{"role":"user","content":"Hello"}]}`,
+			req: &v1.ResponsesRequest{
+				Model: "gpt-4o",
+				Input: v1.ResponsesInput{
+					Array: []v1.ResponsesInputItem{
+						{Role: "user", Content: &v1.ChatMessageContent{String: "Hello"}},
+					},
+				},
+			},
+		},
+		{
+			name: "array input with type field",
+			inputJSON: `{"model":"gpt-4o","input":[{"type":"message","role":"user","content":"Hi"}]}`,
+			req: &v1.ResponsesRequest{
+				Model: "gpt-4o",
+				Input: v1.ResponsesInput{
+					Array: []v1.ResponsesInputItem{
+						{Type: "message", Role: "user", Content: &v1.ChatMessageContent{String: "Hi"}},
+					},
+				},
+			},
+		},
+		{
+			name: "instructions and stream",
+			inputJSON: `{"model":"gpt-4o","input":"Hello","instructions":"You are helpful","stream":true}`,
+			req: &v1.ResponsesRequest{
+				Model:        "gpt-4o",
+				Input:        v1.ResponsesInput{String: "Hello"},
+				Instructions: "You are helpful",
+				Stream:       true,
+			},
+		},
+		{
+			name:      "previous_response_id",
+			inputJSON: `{"model":"gpt-4o","input":"Follow up","previous_response_id":"resp_abc123"}`,
+			req: &v1.ResponsesRequest{
+				Model:              "gpt-4o",
+				Input:              v1.ResponsesInput{String: "Follow up"},
+				PreviousResponseID: "resp_abc123",
+			},
+		},
+		{
+			name:      "max_output_tokens",
+			inputJSON: `{"model":"gpt-4o","input":"Hi","max_output_tokens":512}`,
+			req: &v1.ResponsesRequest{
+				Model:           "gpt-4o",
+				Input:           v1.ResponsesInput{String: "Hi"},
+				MaxOutputTokens: v1.Ptr(512),
+			},
+		},
+		{
+			name:      "extra backend field preserved",
+			inputJSON: `{"model":"gpt-4o","input":"Hi","vllm_extra_param":"value"}`,
+			req: &v1.ResponsesRequest{
+				Model: "gpt-4o",
+				Input: v1.ResponsesInput{String: "Hi"},
+			},
+		},
+		{
+			name: "multipart content in array input",
+			inputJSON: `{"model":"gpt-4o","input":[{"role":"user","content":[{"type":"text","text":"What is this?"},{"type":"image_url","image_url":{"url":"https://example.com/img.jpg"}}]}]}`,
+			req: &v1.ResponsesRequest{
+				Model: "gpt-4o",
+				Input: v1.ResponsesInput{
+					Array: []v1.ResponsesInputItem{
+						{
+							Role: "user",
+							Content: &v1.ChatMessageContent{
+								Array: []v1.ChatMessageContentPart{
+									{Type: "text", Text: "What is this?"},
+									{Type: "image_url", ImageURL: &v1.ChatMessageImageURL{URL: "https://example.com/img.jpg"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multi-turn conversation",
+			inputJSON: `{"model":"gpt-4o","input":[{"role":"system","content":"Be concise"},{"role":"user","content":"Hello"},{"role":"assistant","content":"Hi!"},{"role":"user","content":"How are you?"}]}`,
+			req: &v1.ResponsesRequest{
+				Model: "gpt-4o",
+				Input: v1.ResponsesInput{
+					Array: []v1.ResponsesInputItem{
+						{Role: "system", Content: &v1.ChatMessageContent{String: "Be concise"}},
+						{Role: "user", Content: &v1.ChatMessageContent{String: "Hello"}},
+						{Role: "assistant", Content: &v1.ChatMessageContent{String: "Hi!"}},
+						{Role: "user", Content: &v1.ChatMessageContent{String: "How are you?"}},
+					},
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.True(t, stdjson.Valid([]byte(c.inputJSON)), "test case must be valid JSON")
+
+			var req v1.ResponsesRequest
+			require.NoError(t, json.Unmarshal([]byte(c.inputJSON), &req), "unmarshal error")
+
+			if c.req != nil {
+				unknown := req.Unknown
+				req.Unknown = nil
+				require.EqualValues(t, *c.req, req, "expected struct values")
+				req.Unknown = unknown
+			}
+
+			out, err := json.Marshal(req)
+			require.NoError(t, err, "marshal error")
+
+			if c.roundTripJSON != "" {
+				require.JSONEq(t, c.roundTripJSON, string(out), "expected specific round-trip JSON")
+			} else {
+				require.JSONEq(t, c.inputJSON, string(out), "expected round-trip JSON to remain unchanged")
+			}
+		})
+	}
+}

--- a/internal/apiutils/request.go
+++ b/internal/apiutils/request.go
@@ -175,7 +175,7 @@ func (r *Request) readJSONBody(body io.Reader, path string) error {
 	case "/v1/rerank":
 		r.modelRequest = &openaiv1.RerankRequest{}
 	case "/v1/responses":
-		r.modelRequest = &openaiv1.ChatCompletionRequest{}
+		r.modelRequest = &openaiv1.ResponsesRequest{}
 	default:
 		return fmt.Errorf("unknown path: %q", path)
 	}


### PR DESCRIPTION
Closes #640

Introduces proper type support for the OpenAI Responses API (`POST /v1/responses`), replacing the stub that incorrectly reused `ChatCompletionRequest`.

Adds `ResponsesRequest`, `ResponsesInput`, and `ResponsesInputItem` types. `ResponsesInput` handles the polymorphic `input` field (plain string or array of items). Unknown fields are preserved to pass through backend-specific extensions. Routes `/v1/responses` to the new `ResponsesRequest` in `apiutils`. Includes unit tests for JSON round-trip and `Prefix()` extraction.