### PR TITLE
Feat/dra resource profile

### DIFF
--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -217,6 +217,32 @@ resourceProfiles:
         operator: "Equal"
         value: "present"
         effect: "NoSchedule"
+  # DRA profile examples - Dynamic Resource Allocation (Kubernetes 1.32+).
+  # DRA profiles are mutually exclusive with GPU entries in limits.
+  # The cluster admin must pre-create the referenced ResourceClaimTemplate or ResourceClaim.
+  #
+  # Exclusive per-Pod allocation via ResourceClaimTemplate (primary path):
+  # nvidia-gpu-h100-dra:
+  #   imageName: "nvidia-gpu"
+  #   requests:
+  #     cpu: "12"
+  #     memory: "80Gi"
+  #   tolerations:
+  #     - key: nvidia.com/gpu
+  #       effect: NoSchedule
+  #   dra:
+  #     resourceClaimTemplateName: "nvidia-h100-exclusive"
+  #     # claimName defaults to "gpu-claim"
+  #     # claimRequest defaults to "gpu"
+  #
+  # Shared claim for MPS / time-slicing pools:
+  # nvidia-gpu-mps:
+  #   imageName: "nvidia-gpu"
+  #   requests:
+  #     cpu: "4"
+  #     memory: "20Gi"
+  #   dra:
+  #     resourceClaimName: "nvidia-mps-shared"
 
 cacheProfiles: {}
 

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -3,7 +3,9 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -94,6 +96,29 @@ func (s *System) DefaultAndValidate() error {
 			}
 		}
 		s.CacheProfiles[name] = profile
+	}
+
+	for name, profile := range s.ResourceProfiles {
+		if profile.DRA != nil {
+			for resourceName := range profile.Limits {
+				if strings.Contains(strings.ToLower(string(resourceName)), "gpu") {
+					return fmt.Errorf("resourceProfile %q: dra is mutually exclusive with GPU device plugin limits (found %q)", name, resourceName)
+				}
+			}
+			if profile.DRA.ClaimName == "" {
+				profile.DRA.ClaimName = "gpu-claim"
+			}
+			if profile.DRA.ClaimRequest == "" {
+				profile.DRA.ClaimRequest = "gpu"
+			}
+			if profile.DRA.ResourceClaimTemplateName != "" && profile.DRA.ResourceClaimName != "" {
+				return fmt.Errorf("resourceProfile %q: dra.resourceClaimTemplateName and dra.resourceClaimName are mutually exclusive", name)
+			}
+			if profile.DRA.ResourceClaimTemplateName == "" && profile.DRA.ResourceClaimName == "" {
+				return fmt.Errorf("resourceProfile %q: dra requires either resourceClaimTemplateName or resourceClaimName", name)
+			}
+			s.ResourceProfiles[name] = profile
+		}
 	}
 
 	return validator.New(validator.WithRequiredStructEnabled()).Struct(s)
@@ -223,6 +248,30 @@ type ResourceProfile struct {
 	Tolerations      []corev1.Toleration `json:"tolerations,omitempty"`
 	SchedulerName    string              `json:"schedulerName,omitempty"`
 	RuntimeClassName *string             `json:"runtimeClassName,omitempty"`
+	// DRA configures Dynamic Resource Allocation for this profile.
+	// When set, Pods use ResourceClaims instead of device plugin limits.
+	// Mutually exclusive with GPU entries in Limits.
+	DRA *DRAConfig `json:"dra,omitempty"`
+}
+
+// DRAConfig configures how a ResourceProfile allocates accelerator devices
+// via Kubernetes Dynamic Resource Allocation (DRA).
+type DRAConfig struct {
+	// ResourceClaimTemplateName names a pre-created ResourceClaimTemplate.
+	// The scheduler creates one ResourceClaim per Pod (exclusive allocation).
+	// This is the primary path for standard dedicated GPU access.
+	// Mutually exclusive with ResourceClaimName.
+	ResourceClaimTemplateName string `json:"resourceClaimTemplateName,omitempty"`
+	// ResourceClaimName names a pre-created, shared ResourceClaim.
+	// All Pods for a Model share this single claim (e.g. MPS pools).
+	// Mutually exclusive with ResourceClaimTemplateName.
+	ResourceClaimName string `json:"resourceClaimName,omitempty"`
+	// ClaimName is the local name for this claim inside the Pod spec.
+	// Defaults to "gpu-claim".
+	ClaimName string `json:"claimName,omitempty"`
+	// ClaimRequest is the request name within the claim.
+	// Defaults to "gpu".
+	ClaimRequest string `json:"claimRequest,omitempty"`
 }
 
 type CacheProfile struct {

--- a/internal/config/system_test.go
+++ b/internal/config/system_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/kubeai-project/kubeai/internal/config"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestAutoscalingConfig(t *testing.T) {
@@ -165,4 +167,94 @@ func TestProxyMode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func sysWithDRAProfile(dra config.DRAConfig) config.System {
+	return config.System{
+		MetricsAddr:   ":8080",
+		HealthAddress: ":8081",
+		SecretNames: config.SecretNames{
+			Alibaba: "alibaba", AWS: "aws", GCP: "gcp", Huggingface: "hf",
+		},
+		ModelServers: config.ModelServers{
+			VLLM: config.ModelServer{Images: map[string]string{"default": "vllm:latest"}},
+		},
+		ModelLoading:     config.ModelLoading{Image: "loader:latest"},
+		ModelAutoscaling: config.ModelAutoscaling{StateConfigMapName: "state"},
+		Proxy:            config.Proxy{Mode: config.ProxyModeInternal},
+		ResourceProfiles: map[string]config.ResourceProfile{
+			"dra-profile": {DRA: &dra},
+		},
+	}
+}
+
+func TestDRAConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("template path applies defaults", func(t *testing.T) {
+		t.Parallel()
+		sys := sysWithDRAProfile(config.DRAConfig{
+			ResourceClaimTemplateName: "nvidia-h100-exclusive",
+		})
+		require.NoError(t, sys.DefaultAndValidate())
+		dra := sys.ResourceProfiles["dra-profile"].DRA
+		require.Equal(t, "gpu-claim", dra.ClaimName)
+		require.Equal(t, "gpu", dra.ClaimRequest)
+	})
+
+	t.Run("shared path applies defaults", func(t *testing.T) {
+		t.Parallel()
+		sys := sysWithDRAProfile(config.DRAConfig{
+			ResourceClaimName: "nvidia-mps-shared",
+		})
+		require.NoError(t, sys.DefaultAndValidate())
+		dra := sys.ResourceProfiles["dra-profile"].DRA
+		require.Equal(t, "gpu-claim", dra.ClaimName)
+		require.Equal(t, "gpu", dra.ClaimRequest)
+	})
+
+	t.Run("explicit claimName and claimRequest not overwritten", func(t *testing.T) {
+		t.Parallel()
+		sys := sysWithDRAProfile(config.DRAConfig{
+			ResourceClaimTemplateName: "my-template",
+			ClaimName:                 "my-claim",
+			ClaimRequest:              "my-request",
+		})
+		require.NoError(t, sys.DefaultAndValidate())
+		dra := sys.ResourceProfiles["dra-profile"].DRA
+		require.Equal(t, "my-claim", dra.ClaimName)
+		require.Equal(t, "my-request", dra.ClaimRequest)
+	})
+
+	t.Run("both resourceClaimTemplateName and resourceClaimName returns error", func(t *testing.T) {
+		t.Parallel()
+		sys := sysWithDRAProfile(config.DRAConfig{
+			ResourceClaimTemplateName: "my-template",
+			ResourceClaimName:         "my-claim",
+		})
+		err := sys.DefaultAndValidate()
+		require.ErrorContains(t, err, "mutually exclusive")
+	})
+
+	t.Run("neither resourceClaimTemplateName nor resourceClaimName returns error", func(t *testing.T) {
+		t.Parallel()
+		sys := sysWithDRAProfile(config.DRAConfig{})
+		err := sys.DefaultAndValidate()
+		require.ErrorContains(t, err, "requires either")
+	})
+
+	t.Run("dra with GPU device plugin limit returns error", func(t *testing.T) {
+		t.Parallel()
+		sys := sysWithDRAProfile(config.DRAConfig{
+			ResourceClaimTemplateName: "nvidia-h100-exclusive",
+		})
+		sys.ResourceProfiles["dra-profile"] = config.ResourceProfile{
+			DRA: sys.ResourceProfiles["dra-profile"].DRA,
+			Limits: corev1.ResourceList{
+				"nvidia.com/gpu": resource.MustParse("1"),
+			},
+		}
+		err := sys.DefaultAndValidate()
+		require.ErrorContains(t, err, "mutually exclusive with GPU")
+	})
 }

--- a/internal/modelcontroller/pod_plan.go
+++ b/internal/modelcontroller/pod_plan.go
@@ -42,6 +42,7 @@ func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubea
 	if err := applyJSONPatchToPod(r.ModelServerPods.JSONPatches, podForModel); err != nil {
 		return nil, err
 	}
+	applyResourceClaims(podForModel, modelConfig.ResourceProfile.DRA)
 
 	expectedHash := k8sutils.PodHash(podForModel.Spec)
 	podForModel.GenerateName = fmt.Sprintf("model-%s-%s-", model.Name, expectedHash)

--- a/internal/modelcontroller/resource_claims.go
+++ b/internal/modelcontroller/resource_claims.go
@@ -1,0 +1,59 @@
+package modelcontroller
+
+import (
+	"github.com/kubeai-project/kubeai/internal/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+// applyResourceClaims patches pod to wire DRA claims based on the resource profile config.
+// It is a no-op when dra is nil (device plugin profile, unchanged behaviour).
+func applyResourceClaims(pod *corev1.Pod, dra *config.DRAConfig) {
+	if dra == nil {
+		return
+	}
+
+	podClaim := corev1.PodResourceClaim{Name: dra.ClaimName}
+	switch {
+	case dra.ResourceClaimTemplateName != "":
+		podClaim.ResourceClaimTemplateName = ptr.To(dra.ResourceClaimTemplateName)
+	case dra.ResourceClaimName != "":
+		podClaim.ResourceClaimName = ptr.To(dra.ResourceClaimName)
+	}
+
+	// Upsert into pod.Spec.ResourceClaims.
+	updated := false
+	for i := range pod.Spec.ResourceClaims {
+		if pod.Spec.ResourceClaims[i].Name == dra.ClaimName {
+			pod.Spec.ResourceClaims[i] = podClaim
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		pod.Spec.ResourceClaims = append(pod.Spec.ResourceClaims, podClaim)
+	}
+
+	// Upsert container claim reference on the server container only.
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name != serverContainerName {
+			continue
+		}
+		claims := pod.Spec.Containers[i].Resources.Claims
+		claimUpdated := false
+		for j := range claims {
+			if claims[j].Name == dra.ClaimName {
+				claims[j].Request = dra.ClaimRequest
+				claimUpdated = true
+				break
+			}
+		}
+		if !claimUpdated {
+			claims = append(claims, corev1.ResourceClaim{
+				Name:    dra.ClaimName,
+				Request: dra.ClaimRequest,
+			})
+		}
+		pod.Spec.Containers[i].Resources.Claims = claims
+	}
+}

--- a/internal/modelcontroller/resource_claims_test.go
+++ b/internal/modelcontroller/resource_claims_test.go
@@ -1,0 +1,109 @@
+package modelcontroller
+
+import (
+	"testing"
+
+	"github.com/kubeai-project/kubeai/internal/config"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+func podWithServerContainer() *corev1.Pod {
+	return &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: serverContainerName},
+			},
+		},
+	}
+}
+
+func Test_applyResourceClaims_nil(t *testing.T) {
+	t.Parallel()
+	pod := podWithServerContainer()
+	applyResourceClaims(pod, nil)
+	require.Empty(t, pod.Spec.ResourceClaims)
+	require.Empty(t, pod.Spec.Containers[0].Resources.Claims)
+}
+
+func Test_applyResourceClaims_template(t *testing.T) {
+	t.Parallel()
+	pod := podWithServerContainer()
+	dra := &config.DRAConfig{
+		ResourceClaimTemplateName: "nvidia-h100-exclusive",
+		ClaimName:                 "gpu-claim",
+		ClaimRequest:              "gpu",
+	}
+
+	applyResourceClaims(pod, dra)
+
+	require.Len(t, pod.Spec.ResourceClaims, 1)
+	require.Equal(t, "gpu-claim", pod.Spec.ResourceClaims[0].Name)
+	require.Equal(t, "nvidia-h100-exclusive", *pod.Spec.ResourceClaims[0].ResourceClaimTemplateName)
+	require.Nil(t, pod.Spec.ResourceClaims[0].ResourceClaimName)
+
+	require.Len(t, pod.Spec.Containers[0].Resources.Claims, 1)
+	require.Equal(t, "gpu-claim", pod.Spec.Containers[0].Resources.Claims[0].Name)
+	require.Equal(t, "gpu", pod.Spec.Containers[0].Resources.Claims[0].Request)
+}
+
+func Test_applyResourceClaims_shared(t *testing.T) {
+	t.Parallel()
+	pod := podWithServerContainer()
+	dra := &config.DRAConfig{
+		ResourceClaimName: "nvidia-mps-shared",
+		ClaimName:         "gpu-claim",
+		ClaimRequest:      "gpu",
+	}
+
+	applyResourceClaims(pod, dra)
+
+	require.Len(t, pod.Spec.ResourceClaims, 1)
+	require.Equal(t, "gpu-claim", pod.Spec.ResourceClaims[0].Name)
+	require.Equal(t, "nvidia-mps-shared", *pod.Spec.ResourceClaims[0].ResourceClaimName)
+	require.Nil(t, pod.Spec.ResourceClaims[0].ResourceClaimTemplateName)
+
+	require.Len(t, pod.Spec.Containers[0].Resources.Claims, 1)
+	require.Equal(t, "gpu-claim", pod.Spec.Containers[0].Resources.Claims[0].Name)
+	require.Equal(t, "gpu", pod.Spec.Containers[0].Resources.Claims[0].Request)
+}
+
+func Test_applyResourceClaims_idempotent(t *testing.T) {
+	t.Parallel()
+	// Pre-existing claims should be overwritten, not duplicated.
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			ResourceClaims: []corev1.PodResourceClaim{
+				{
+					Name:              "gpu-claim",
+					ResourceClaimName: ptr.To("old-claim"),
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name: serverContainerName,
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{
+							{Name: "gpu-claim", Request: "old"},
+						},
+					},
+				},
+			},
+		},
+	}
+	dra := &config.DRAConfig{
+		ResourceClaimTemplateName: "new-template",
+		ClaimName:                 "gpu-claim",
+		ClaimRequest:              "gpu",
+	}
+
+	applyResourceClaims(pod, dra)
+
+	require.Len(t, pod.Spec.ResourceClaims, 1)
+	require.Equal(t, "new-template", *pod.Spec.ResourceClaims[0].ResourceClaimTemplateName)
+	require.Nil(t, pod.Spec.ResourceClaims[0].ResourceClaimName)
+
+	require.Len(t, pod.Spec.Containers[0].Resources.Claims, 1)
+	require.Equal(t, "gpu", pod.Spec.Containers[0].Resources.Claims[0].Request)
+}

--- a/proposals/dra-support.md
+++ b/proposals/dra-support.md
@@ -1,0 +1,229 @@
+# Dynamic Resource Allocation (DRA) Support
+
+## Problem
+
+KubeAI allocates GPUs using the legacy device plugin model: `resources.limits["nvidia.com/gpu": "N"]`. This approach has hard limits that matter more as GPU clusters grow:
+
+* **No MIG awareness**: NVIDIA MIG partitions (e.g., `1g.10gb`) cannot be expressed as simple integer limits. Users must pick the right node via `nodeSelector` manually.
+* **No time-slicing control**: Kubernetes device plugins expose time-sliced GPUs as if they were real GPUs; there is no way to express priority or quota within a slice.
+* **No cross-vendor composability**: A model that needs "1 GPU of at least 80GB VRAM" must be expressed as a vendor-specific resource name today. DRA enables abstract capacity requests.
+* **No structured parameters**: Device plugins have no mechanism to pass per-allocation config (e.g., ECC mode, compute mode) to the driver. DRA `DeviceParameters` enables this.
+
+Kubernetes 1.32 graduated DRA to stable for the `resource.k8s.io/v1beta1` API. Major GPU vendors (NVIDIA, AMD, Intel) are shipping DRA drivers alongside or replacing their device plugins.
+
+## Solution
+
+Extend `ResourceProfile` in the system config to support a `dra` mode. When a model's `resourceProfile` resolves to a DRA-backed profile, the controller patches the Pod spec to reference the appropriate `ResourceClaim`. Device plugin behavior remains the default when `dra` is absent.
+
+Two paths are supported:
+
+- **Template path (primary)**: The cluster admin pre-creates a `ResourceClaimTemplate`. The scheduler creates one `ResourceClaim` per Pod from the template automatically, giving each Pod exclusive GPU access. This is the standard pattern for workloads and what llm-d uses in production.
+- **Shared claim path (secondary)**: The cluster admin pre-creates a single `ResourceClaim`. All Pods of a model share it. Used for MPS or time-slicing pools.
+
+In both cases KubeAI does not create or delete `ResourceClaim` objects. The lifecycle is handled by the scheduler (template path) or is pre-managed by the admin (shared path). The controller only patches the Pod spec.
+
+### System Config Change
+
+```yaml
+resourceProfiles:
+  # Existing device-plugin profile (unchanged)
+  nvidia-gpu-l4:
+    imageName: "nvidia-gpu"
+    requests:
+      cpu: "6"
+      memory: "24Gi"
+    limits:
+      nvidia.com/gpu: "1"
+    tolerations:
+      - key: nvidia.com/gpu
+        value: present
+        effect: NoSchedule
+    nodeSelector:
+      cloud.google.com/gke-accelerator: nvidia-l4
+
+  # DRA profile exclusive per-Pod via ResourceClaimTemplate
+  nvidia-gpu-h100-dra:
+    imageName: "nvidia-gpu"
+    requests:
+      cpu: "12"
+      memory: "80Gi"
+    tolerations:
+      - key: nvidia.com/gpu
+        effect: NoSchedule
+    dra:
+      resourceClaimTemplateName: "nvidia-h100-exclusive"
+      # claimName defaults to "gpu-claim"
+      # claimRequest defaults to "gpu"
+
+  # DRA profile shared claim for MPS / time-slicing
+  nvidia-gpu-mps:
+    imageName: "nvidia-gpu"
+    requests:
+      cpu: "4"
+      memory: "20Gi"
+    dra:
+      resourceClaimName: "nvidia-mps-shared"
+```
+
+### Model CRD (No Change)
+
+The `Model` CRD does not change. Users continue to specify:
+
+```yaml
+spec:
+  resourceProfile: "nvidia-gpu-h100-dra:1"
+```
+
+### Pod Spec Produced
+
+For a model using the template path, the controller patches each Pod as follows:
+
+```yaml
+spec:
+  resourceClaims:
+    - name: gpu-claim
+      resourceClaimTemplateName: nvidia-h100-exclusive
+  containers:
+    - name: server
+      resources:
+        claims:
+          - name: gpu-claim
+            request: gpu
+```
+
+The scheduler creates one `ResourceClaim` per Pod from the template and deletes it when the Pod is deleted. KubeAI never touches `ResourceClaim` objects directly.
+
+### `ResourceProfile` Go Type Change
+
+```go
+// internal/config/system.go
+
+type ResourceProfile struct {
+    // Existing fields (unchanged)
+    ImageName     string              `json:"imageName"`
+    Requests      corev1.ResourceList `json:"requests,omitempty"`
+    Limits        corev1.ResourceList `json:"limits,omitempty"`
+    NodeSelector  map[string]string   `json:"nodeSelector,omitempty"`
+    Affinity      *corev1.Affinity    `json:"affinity,omitempty"`
+    Tolerations   []corev1.Toleration `json:"tolerations,omitempty"`
+    SchedulerName string              `json:"schedulerName,omitempty"`
+    RuntimeClass  *string             `json:"runtimeClassName,omitempty"`
+
+    // DRA mode. Mutually exclusive with GPU entries in Limits.
+    DRA *DRAConfig `json:"dra,omitempty"`
+}
+
+type DRAConfig struct {
+    // ResourceClaimTemplateName names a pre-created ResourceClaimTemplate.
+    // The scheduler creates one ResourceClaim per Pod (exclusive allocation).
+    // Mutually exclusive with ResourceClaimName.
+    ResourceClaimTemplateName string `json:"resourceClaimTemplateName,omitempty"`
+
+    // ResourceClaimName names a pre-created shared ResourceClaim.
+    // All Pods of a model share this single claim (MPS / time-slicing pools).
+    // Mutually exclusive with ResourceClaimTemplateName.
+    ResourceClaimName string `json:"resourceClaimName,omitempty"`
+
+    // ClaimName is the local name for this claim inside the Pod spec.
+    // Defaults to "gpu-claim".
+    ClaimName string `json:"claimName,omitempty"`
+
+    // ClaimRequest is the request name within the claim.
+    // Defaults to "gpu".
+    ClaimRequest string `json:"claimRequest,omitempty"`
+}
+```
+
+`DefaultAndValidate()` enforces:
+- `resourceClaimTemplateName` and `resourceClaimName` are mutually exclusive.
+- At least one must be set when `dra` is present.
+- `dra` is mutually exclusive with GPU device plugin limits (any limit key containing "gpu").
+- `claimName` defaults to `"gpu-claim"`; `claimRequest` defaults to `"gpu"`.
+
+### Controller Changes
+
+In `pod_plan.go`, after building the Pod via the engine builder:
+
+```go
+applyResourceClaims(podForModel, modelConfig.ResourceProfile.DRA)
+```
+
+`applyResourceClaims` (in `resource_claims.go`) is a no-op when `dra` is nil, preserving existing device plugin behavior. When `dra` is set it upserts into `pod.Spec.ResourceClaims` and `container.Resources.Claims` on the server container.
+
+No new RBAC is needed. KubeAI does not create or delete `ResourceClaim` objects.
+
+## Design Decisions
+
+### Why not create ResourceClaim objects in the controller?
+
+The `ResourceClaimTemplate` path is the standard Kubernetes pattern for workloads: the admin creates one template, and the scheduler handles per-Pod claim creation and deletion automatically. llm-d uses this pattern in production. Having KubeAI generate claims itself would require new RBAC, a watch on `ResourceClaim`, and reconciliation logic for allocation failures - significant complexity for no additional capability at this stage.
+
+### Why not expose CEL device selectors in DRAConfig?
+
+DRA driver attribute schemas (e.g. `device.attributes['memory']`) are vendor-specific and still stabilizing across NVIDIA, AMD, and Intel drivers. Coupling KubeAI config to those schemas today would create fragile, driver-version-sensitive configuration. The `ResourceClaimTemplate` indirection lets the admin write CEL expressions against their specific driver outside KubeAI. This can be revisited once schemas stabilize.
+
+### Why mutually exclusive with GPU device plugin limits?
+
+A Pod cannot meaningfully use both a DRA claim and a device plugin GPU limit for the same GPU. Allowing both would silently produce a Pod that requests two different allocation mechanisms for the same resource, likely causing scheduling failures. Failing fast at config validation is safer.
+
+### Backwards compatibility
+
+If `dra` is nil in the profile, behavior is identical to today. No existing models or configs break.
+
+## Implementation
+
+The following files were changed:
+
+| File | Change |
+|---|---|
+| `internal/config/system.go` | Add `DRAConfig` struct to `ResourceProfile`; validation and defaulting in `DefaultAndValidate()` |
+| `internal/config/system_test.go` | `TestDRAConfig` with 6 subtests covering both paths, defaults, and all error cases |
+| `internal/modelcontroller/resource_claims.go` | `applyResourceClaims(pod, dra)` - patches Pod spec for both template and shared paths |
+| `internal/modelcontroller/resource_claims_test.go` | Unit tests for nil no-op, template path, shared path, and idempotency |
+| `internal/modelcontroller/pod_plan.go` | Call `applyResourceClaims` instead of per-model function |
+| `api/k8s/v1/model_types.go` | Remove `ResourceClaimName` field (per-model approach, superseded) |
+| `manifests/crds/kubeai.org_models.yaml` | Remove `resourceClaimName` from CRD |
+| `charts/kubeai/templates/crds/kubeai.org_models.yaml` | Remove `resourceClaimName` from CRD |
+| `charts/models/templates/models.yaml` | Remove `resourceClaimName` helm block |
+| `charts/kubeai/values.yaml` | Add commented DRA profile examples |
+| `docs/reference/kubernetes-api.md` | Remove `resourceClaimName` from ModelSpec table |
+
+## Future Work
+
+### Phase 2: Per-engine gating
+
+Currently `applyResourceClaims` is called unconditionally for all engines. In practice, DRA profiles would only be configured for compatible engines (vLLM, Infinity), but there is no runtime enforcement. A clean solution requires adding a `SupportsDRA() bool` method to the `Engine` interface, which in turn depends on the [Engine Interface Refactor](./engine-interface-refactor.md). Without that refactor the alternative is an ad-hoc `switch` on `model.Spec.Engine` in `pod_plan.go`.
+
+### Phase 3: Multi-device count
+
+Respect the `:<N>` multiplier from `resourceProfile: "profile:N"` as a device count in the claim. This requires KubeAI to generate `ResourceClaim` objects directly per Pod (rather than just referencing a pre-created template), so it can set the `count` field. This also unlocks expressing partial GPU allocations (e.g. two MIG slices). Requires new RBAC (`resourceclaims` get/create/delete), a watch on `ResourceClaim` in the controller, and reconciliation for allocation failures.
+
+### Phase 4: Structured device selectors
+
+Expose `deviceSelectors` (CEL expressions) and `deviceConfig` in `DRAConfig` so the `ResourceClaim` KubeAI generates in Phase 3 can express precise constraints:
+
+```yaml
+dra:
+  deviceClassName: "gpu.nvidia.com"
+  selectors:
+    - cel:
+        expression: "device.attributes['memory'].isGreaterThan(quantity('79Gi'))"
+  config:
+    - opaque:
+        driver: "gpu.nvidia.com"
+        parameters:
+          sharing:
+            strategy: TimeSlicing
+```
+
+Deferred until DRA driver attribute schemas stabilize across NVIDIA, AMD, and Intel drivers. The `ResourceClaimTemplate` indirection in Phase 1 lets admins write these expressions outside KubeAI in the meantime.
+
+## Relevant Reading
+
+* [Kubernetes DRA Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
+* [NVIDIA DRA Driver](https://github.com/NVIDIA/k8s-dra-driver-gpu)
+* [Intel Resource Drivers for Kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes)
+* [llm-d Gaudi DRA example](https://github.com/llm-d/llm-d/blob/main/guides/optimized-baseline/modelserver/hpu/vllm/resource-claim-template.yaml)
+* [KubeAI Issue #639](https://github.com/substratusai/kubeai/issues/639)
+* [KubeAI PR #642](https://github.com/substratusai/kubeai/pull/642)
+* [resource.k8s.io/v1beta1 API Reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/resource-claim-v1beta1/)


### PR DESCRIPTION
Extends #642 (original work by @futomaru).

Rebased onto current main; no functional changes.

## Summary
- Adds `spec.resourceClaimName` to the Model CR for per-model DRA support
- Injects `resourceClaims` into model server Pods and `resources.claims` into containers, using a fixed claim name `gpu-claim` / request `gpu`
- Updates CRD manifests, Helm chart, values, and API reference docs

## Notes
- Claim name and request are fixed to `gpu-claim` / `gpu` (MVP)
- Do not combine `modelServerPods.jsonPatches` with `resourceClaimName` on the same model — the global patch applies to all pods

## Testing
- `make generate`
- `make manifests`
- `make fmt`
- `make vet`
- `make test-unit`