### PR TITLE
(feat) expose proxy.mode in Helm chart

### DIFF
--- a/charts/kubeai/templates/configmap.yaml
+++ b/charts/kubeai/templates/configmap.yaml
@@ -11,6 +11,8 @@ data:
       aws: {{ include "kubeai.awsSecretName" . }}
       gcp: {{ include "kubeai.gcpSecretName" . }}
       huggingface: {{ include "kubeai.huggingfaceSecretName" . }}
+    proxy:
+      mode: {{ .Values.proxy.mode }}
     resourceProfiles:
       {{- .Values.resourceProfiles | toYaml | nindent 6 }}
     cacheProfiles:

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -93,6 +93,12 @@ modelRollouts:
   # The number of replicas to add when rolling out a new model.
   surge: 1
 
+proxy:
+  # Mode controls how the KubeAI proxy handles model endpoints.
+  # "internal" uses pod IPs directly; "external" defers to an external load balancer.
+  # Valid values: internal, external
+  mode: "internal"
+
 metrics:
   prometheusOperator:
     vLLMPodMonitor:


### PR DESCRIPTION
Follow-up to #655: exposes the `proxy.mode` config field as a Helm value so users can set `proxy.mode=external` without manually patching the ConfigMap.