### PR TITLE
ci: add Go linting workflow with golangci-lint v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run linter
+        run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
+version: "2"
+
 run:
   timeout: 5m
-  allow-parallel-runners: true
 
 issues:
   # don't skip warning about doc comments
@@ -16,18 +17,15 @@ issues:
       linters:
         - dupl
         - lll
+
 linters:
   disable-all: true
   enable:
     - dupl
     - errcheck
-    - exportloopref
     - ginkgolinter
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -36,12 +34,14 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
-    - unused
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
 
-linters-settings:
-  revive:
-    rules:
-      - name: comment-spacings
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ YQ ?= $(LOCALBIN)/yq
 KUSTOMIZE_VERSION ?= v5.4.2
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
 ENVTEST_VERSION ?= release-0.22
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v2.1.6
 YQ_VERSION ?= v4.44.3
 
 .PHONY: kustomize
@@ -193,7 +193,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 .PHONY: yq
 yq: $(YQ) ## Download yq locally if necessary.


### PR DESCRIPTION
Go linting was never enforced in CI — only available locally via `make lint`.

Adds `.github/workflows/lint.yml` to run `make lint` on every push to `main` and on PRs. Migrates `.golangci.yml` to the v2 config format (`linters-settings` moved under `linters.settings`, `allow-parallel-runners` removed, `exportloopref` dropped since it was removed in golangci-lint v1.61 after Go 1.22 fixed loop variable capture). Bumps golangci-lint from v1.59.1 to v2.1.6 in the Makefile.