### PR TITLE
refactor: introduce SourceRegistry for model source dispatch

### DIFF
--- a/internal/modelcontroller/adapters.go
+++ b/internal/modelcontroller/adapters.go
@@ -168,7 +168,7 @@ func adapterDir(a v1.Adapter) string {
 	return fmt.Sprintf("%s/%s", adaptersRootDir, a.Name)
 }
 
-func (r *ModelReconciler) patchServerAdapterLoader(podSpec *corev1.PodSpec, m *v1.Model, image string) {
+func patchServerAdapterLoader(podSpec *corev1.PodSpec, m *v1.Model, cfg EngineConfig) {
 	if m.Spec.Adapters == nil {
 		return
 	}
@@ -202,10 +202,10 @@ func (r *ModelReconciler) patchServerAdapterLoader(podSpec *corev1.PodSpec, m *v
 
 	loaderContainer := corev1.Container{
 		Name:            loaderContainerName,
-		Image:           image,
+		Image:           cfg.ModelLoaders.Image,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Env:             env,
-		SecurityContext: r.ModelServerPods.ModelContainerSecurityContext,
+		SecurityContext: cfg.ModelServerPods.ModelContainerSecurityContext,
 		Command:         []string{"sleep", "infinity"},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -215,8 +215,8 @@ func (r *ModelReconciler) patchServerAdapterLoader(podSpec *corev1.PodSpec, m *v
 		},
 	}
 	podSpec.Containers = append(podSpec.Containers, loaderContainer)
-	r.modelAuthCredentialsForAllSources().applyToPodSpec(podSpec, len(podSpec.Containers)-1)
-	r.modelEnvFrom(m).applyToPodSpec(podSpec, len(podSpec.Containers)-1)
+	modelAuthCredentialsForAllSources(cfg.SecretNames).applyToPodSpec(podSpec, len(podSpec.Containers)-1)
+	modelEnvFrom(m).applyToPodSpec(podSpec, len(podSpec.Containers)-1)
 }
 
 func getLabelledAdapters(pod *corev1.Pod) map[string]struct{} {

--- a/internal/modelcontroller/engine.go
+++ b/internal/modelcontroller/engine.go
@@ -1,0 +1,44 @@
+package modelcontroller
+
+import (
+	"fmt"
+
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/config"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EngineConfig holds the configuration that engine implementations need to build pods.
+// It is intentionally narrow — engines should not depend on the full ModelReconciler.
+type EngineConfig struct {
+	AllowPodAddressOverride bool
+	ModelServerPods         config.ModelServerPods
+	ModelLoaders            config.ModelLoading
+	SecretNames             config.SecretNames
+}
+
+type Engine interface {
+	PodForModel(m *kubeaiv1.Model, c ModelConfig) *corev1.Pod
+}
+
+type EngineRegistry struct {
+	engines map[string]Engine
+}
+
+func NewEngineRegistry(cfg EngineConfig) *EngineRegistry {
+	return &EngineRegistry{
+		engines: map[string]Engine{
+			kubeaiv1.VLLMEngine:          &VLLMEngine{cfg: cfg},
+			kubeaiv1.OLlamaEngine:        &OLlamaEngine{cfg: cfg},
+			kubeaiv1.FasterWhisperEngine: &FasterWhisperEngine{cfg: cfg},
+			kubeaiv1.InfinityEngine:      &InfinityEngine{cfg: cfg},
+		},
+	}
+}
+
+func (reg *EngineRegistry) Get(name string) (Engine, error) {
+	if e, ok := reg.engines[name]; ok {
+		return e, nil
+	}
+	return nil, fmt.Errorf("unknown engine: %q", name)
+}

--- a/internal/modelcontroller/engine_fasterwhisper.go
+++ b/internal/modelcontroller/engine_fasterwhisper.go
@@ -9,9 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (r *ModelReconciler) fasterWhisperPodForModel(m *kubeaiv1.Model, c ModelConfig) *corev1.Pod {
+type FasterWhisperEngine struct {
+	cfg EngineConfig
+}
+
+func (e *FasterWhisperEngine) PodForModel(m *kubeaiv1.Model, c ModelConfig) *corev1.Pod {
 	lbs := labelsForModel(m)
-	ann := r.annotationsForModel(m)
+	ann := annotationsForModel(m, e.cfg.AllowPodAddressOverride)
 	if _, ok := ann[kubeaiv1.ModelPodPortAnnotation]; !ok {
 		ann[kubeaiv1.ModelPodPortAnnotation] = "8000"
 	}
@@ -60,16 +64,16 @@ func (r *ModelReconciler) fasterWhisperPodForModel(m *kubeaiv1.Model, c ModelCon
 			SchedulerName:      c.SchedulerName,
 			RuntimeClassName:   c.RuntimeClassName,
 			PriorityClassName:  m.Spec.PriorityClassName,
-			ServiceAccountName: r.ModelServerPods.ModelServiceAccountName,
-			SecurityContext:    r.ModelServerPods.ModelPodSecurityContext,
-			ImagePullSecrets:   r.ModelServerPods.ImagePullSecrets,
+			ServiceAccountName: e.cfg.ModelServerPods.ModelServiceAccountName,
+			SecurityContext:    e.cfg.ModelServerPods.ModelPodSecurityContext,
+			ImagePullSecrets:   e.cfg.ModelServerPods.ImagePullSecrets,
 			Containers: []corev1.Container{
 				{
 					Name:            serverContainerName,
 					Image:           c.Image,
 					Args:            args,
 					Env:             env,
-					SecurityContext: r.ModelServerPods.ModelContainerSecurityContext,
+					SecurityContext: e.cfg.ModelServerPods.ModelContainerSecurityContext,
 					Resources: corev1.ResourceRequirements{
 						Requests: c.Requests,
 						Limits:   c.Limits,

--- a/internal/modelcontroller/engine_infinity.go
+++ b/internal/modelcontroller/engine_infinity.go
@@ -9,9 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (r *ModelReconciler) infinityPodForModel(m *kubeaiv1.Model, c ModelConfig) *corev1.Pod {
+type InfinityEngine struct {
+	cfg EngineConfig
+}
+
+func (e *InfinityEngine) PodForModel(m *kubeaiv1.Model, c ModelConfig) *corev1.Pod {
 	lbs := labelsForModel(m)
-	ann := r.annotationsForModel(m)
+	ann := annotationsForModel(m, e.cfg.AllowPodAddressOverride)
 
 	args := []string{
 		"v2",
@@ -78,9 +82,9 @@ func (r *ModelReconciler) infinityPodForModel(m *kubeaiv1.Model, c ModelConfig) 
 			SchedulerName:      c.SchedulerName,
 			RuntimeClassName:   c.RuntimeClassName,
 			PriorityClassName:  m.Spec.PriorityClassName,
-			ServiceAccountName: r.ModelServerPods.ModelServiceAccountName,
-			SecurityContext:    r.ModelServerPods.ModelPodSecurityContext,
-			ImagePullSecrets:   r.ModelServerPods.ImagePullSecrets,
+			ServiceAccountName: e.cfg.ModelServerPods.ModelServiceAccountName,
+			SecurityContext:    e.cfg.ModelServerPods.ModelPodSecurityContext,
+			ImagePullSecrets:   e.cfg.ModelServerPods.ImagePullSecrets,
 			Containers: []corev1.Container{
 				{
 					Name:  serverContainerName,

--- a/internal/modelcontroller/engine_ollama.go
+++ b/internal/modelcontroller/engine_ollama.go
@@ -9,9 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (r *ModelReconciler) oLlamaPodForModel(m *kubeaiv1.Model, c ModelConfig) *corev1.Pod {
+type OLlamaEngine struct {
+	cfg EngineConfig
+}
+
+func (e *OLlamaEngine) PodForModel(m *kubeaiv1.Model, c ModelConfig) *corev1.Pod {
 	lbs := labelsForModel(m)
-	ann := r.annotationsForModel(m)
+	ann := annotationsForModel(m, e.cfg.AllowPodAddressOverride)
 
 	if _, ok := ann[kubeaiv1.ModelPodPortAnnotation]; !ok {
 		// Set port to 8000 (vLLM) if not overwritten.
@@ -72,16 +76,16 @@ func (r *ModelReconciler) oLlamaPodForModel(m *kubeaiv1.Model, c ModelConfig) *c
 			SchedulerName:      c.SchedulerName,
 			RuntimeClassName:   c.RuntimeClassName,
 			PriorityClassName:  m.Spec.PriorityClassName,
-			ServiceAccountName: r.ModelServerPods.ModelServiceAccountName,
-			SecurityContext:    r.ModelServerPods.ModelPodSecurityContext,
-			ImagePullSecrets:   r.ModelServerPods.ImagePullSecrets,
+			ServiceAccountName: e.cfg.ModelServerPods.ModelServiceAccountName,
+			SecurityContext:    e.cfg.ModelServerPods.ModelPodSecurityContext,
+			ImagePullSecrets:   e.cfg.ModelServerPods.ImagePullSecrets,
 			Containers: []corev1.Container{
 				{
 					Name:            serverContainerName,
 					Image:           c.Image,
 					Args:            m.Spec.Args,
 					Env:             env,
-					SecurityContext: r.ModelServerPods.ModelContainerSecurityContext,
+					SecurityContext: e.cfg.ModelServerPods.ModelContainerSecurityContext,
 					Resources: corev1.ResourceRequirements{
 						Requests: c.Requests,
 						Limits:   c.Limits,

--- a/internal/modelcontroller/engine_vllm.go
+++ b/internal/modelcontroller/engine_vllm.go
@@ -9,9 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *corev1.Pod {
+type VLLMEngine struct {
+	cfg EngineConfig
+}
+
+func (e *VLLMEngine) PodForModel(m *kubeaiv1.Model, c ModelConfig) *corev1.Pod {
 	lbs := labelsForModel(m)
-	ann := r.annotationsForModel(m)
+	ann := annotationsForModel(m, e.cfg.AllowPodAddressOverride)
 	if _, ok := ann[kubeaiv1.ModelPodPortAnnotation]; !ok {
 		// Set port to 8000 (vLLM) if not overwritten.
 		ann[kubeaiv1.ModelPodPortAnnotation] = "8000"
@@ -76,9 +80,9 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 			SchedulerName:      c.SchedulerName,
 			RuntimeClassName:   c.RuntimeClassName,
 			PriorityClassName:  m.Spec.PriorityClassName,
-			ServiceAccountName: r.ModelServerPods.ModelServiceAccountName,
-			SecurityContext:    r.ModelServerPods.ModelPodSecurityContext,
-			ImagePullSecrets:   r.ModelServerPods.ImagePullSecrets,
+			ServiceAccountName: e.cfg.ModelServerPods.ModelServiceAccountName,
+			SecurityContext:    e.cfg.ModelServerPods.ModelPodSecurityContext,
+			ImagePullSecrets:   e.cfg.ModelServerPods.ImagePullSecrets,
 			Containers: []corev1.Container{
 				{
 					Name:            serverContainerName,
@@ -86,7 +90,7 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 					Command:         []string{"python3", "-m", "vllm.entrypoints.openai.api_server"},
 					Args:            args,
 					Env:             env,
-					SecurityContext: r.ModelServerPods.ModelContainerSecurityContext,
+					SecurityContext: e.cfg.ModelServerPods.ModelContainerSecurityContext,
 					Resources: corev1.ResourceRequirements{
 						Requests: c.Requests,
 						Limits:   c.Limits,
@@ -159,7 +163,7 @@ func (r *ModelReconciler) vLLMPodForModel(m *kubeaiv1.Model, c ModelConfig) *cor
 	}
 
 	patchFileVolumes(&pod.Spec, m)
-	r.patchServerAdapterLoader(&pod.Spec, m, r.ModelLoaders.Image)
+	patchServerAdapterLoader(&pod.Spec, m, e.cfg)
 	patchServerCacheVolumes(&pod.Spec, m, c)
 	c.Source.modelSourcePodAdditions.applyToPodSpec(&pod.Spec, 0)
 

--- a/internal/modelcontroller/model_controller.go
+++ b/internal/modelcontroller/model_controller.go
@@ -70,6 +70,7 @@ type ModelReconciler struct {
 	ModelLoaders            config.ModelLoading
 	ModelRollouts           config.ModelRollouts
 	EngineRegistry          *EngineRegistry
+	SourceRegistry          *SourceRegistry
 }
 
 func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, resErr error) {
@@ -213,6 +214,7 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.SourceRegistry = NewSourceRegistry(r.SecretNames)
 	r.EngineRegistry = NewEngineRegistry(EngineConfig{
 		AllowPodAddressOverride: r.AllowPodAddressOverride,
 		ModelServerPods:         r.ModelServerPods,
@@ -345,7 +347,7 @@ type ModelConfig struct {
 func (r *ModelReconciler) getModelConfig(model *kubeaiv1.Model) (ModelConfig, error) {
 	var result ModelConfig
 
-	src, err := r.parseModelSource(model.Spec.URL)
+	src, err := parseModelSource(model.Spec.URL, r.SourceRegistry)
 	if err != nil {
 		return result, fmt.Errorf("parsing model source: %w", err)
 	}

--- a/internal/modelcontroller/model_controller.go
+++ b/internal/modelcontroller/model_controller.go
@@ -69,6 +69,7 @@ type ModelReconciler struct {
 	ModelServerPods         config.ModelServerPods
 	ModelLoaders            config.ModelLoading
 	ModelRollouts           config.ModelRollouts
+	EngineRegistry          *EngineRegistry
 }
 
 func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, resErr error) {
@@ -212,6 +213,12 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.EngineRegistry = NewEngineRegistry(EngineConfig{
+		AllowPodAddressOverride: r.AllowPodAddressOverride,
+		ModelServerPods:         r.ModelServerPods,
+		ModelLoaders:            r.ModelLoaders,
+		SecretNames:             r.SecretNames,
+	})
 	// TODO: Set Model concurrency. Pod rollouts can be slow.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kubeaiv1.Model{}).
@@ -306,12 +313,12 @@ func labelsForModel(m *kubeaiv1.Model) map[string]string {
 	return podlbmap
 }
 
-func (r *ModelReconciler) annotationsForModel(m *kubeaiv1.Model) map[string]string {
+func annotationsForModel(m *kubeaiv1.Model, allowOverride bool) map[string]string {
 	ann := map[string]string{}
 
 	if modelAnn := m.GetAnnotations(); modelAnn != nil {
 		var keys []string
-		if r.AllowPodAddressOverride {
+		if allowOverride {
 			keys = append(keys,
 				kubeaiv1.ModelPodIPAnnotation,
 				kubeaiv1.ModelPodPortAnnotation,

--- a/internal/modelcontroller/model_controller_test.go
+++ b/internal/modelcontroller/model_controller_test.go
@@ -20,6 +20,7 @@ import (
 
 func Test_getModelConfig(t *testing.T) {
 	r := ModelReconciler{
+		SourceRegistry: NewSourceRegistry(config.SecretNames{}),
 		ResourceProfiles: map[string]config.ResourceProfile{
 			"none": {},
 			"my-gpu": {

--- a/internal/modelcontroller/model_source.go
+++ b/internal/modelcontroller/model_source.go
@@ -17,30 +17,69 @@ type modelSource struct {
 	url modelURL
 }
 
-func (r *ModelReconciler) parseModelSource(urlStr string) (modelSource, error) {
+// ModelSourceProvider is the port for providing pod additions based on model URL scheme.
+type ModelSourceProvider interface {
+	PodAdditions(u modelURL) *modelSourcePodAdditions
+}
+
+type SourceRegistry struct {
+	providers map[string]ModelSourceProvider
+}
+
+func NewSourceRegistry(secretNames config.SecretNames) *SourceRegistry {
+	return &SourceRegistry{
+		providers: map[string]ModelSourceProvider{
+			"s3":  &s3SourceProvider{secretName: secretNames.AWS},
+			"gs":  &gcsSourceProvider{secretName: secretNames.GCP},
+			"oss": &ossSourceProvider{secretName: secretNames.Alibaba},
+			"hf":  &hfSourceProvider{secretName: secretNames.Huggingface},
+			"pvc": &pvcSourceProvider{},
+		},
+	}
+}
+
+func (reg *SourceRegistry) Get(scheme string) ModelSourceProvider {
+	if p, ok := reg.providers[scheme]; ok {
+		return p
+	}
+	return &emptySourceProvider{}
+}
+
+type s3SourceProvider struct{ secretName string }
+type gcsSourceProvider struct{ secretName string }
+type ossSourceProvider struct{ secretName string }
+type hfSourceProvider struct{ secretName string }
+type pvcSourceProvider struct{}
+type emptySourceProvider struct{}
+
+func (p *s3SourceProvider) PodAdditions(_ modelURL) *modelSourcePodAdditions {
+	return authForS3(p.secretName)
+}
+func (p *gcsSourceProvider) PodAdditions(_ modelURL) *modelSourcePodAdditions {
+	return authForGCS(p.secretName)
+}
+func (p *ossSourceProvider) PodAdditions(_ modelURL) *modelSourcePodAdditions {
+	return authForOSS(p.secretName)
+}
+func (p *hfSourceProvider) PodAdditions(_ modelURL) *modelSourcePodAdditions {
+	return authForHuggingfaceHub(p.secretName)
+}
+func (p *pvcSourceProvider) PodAdditions(u modelURL) *modelSourcePodAdditions {
+	return pvcPodAdditions(u)
+}
+func (p *emptySourceProvider) PodAdditions(_ modelURL) *modelSourcePodAdditions {
+	return &modelSourcePodAdditions{}
+}
+
+func parseModelSource(urlStr string, registry *SourceRegistry) (modelSource, error) {
 	u, err := parseModelURL(urlStr)
 	if err != nil {
 		return modelSource{}, err
 	}
-	src := modelSource{
-		url: u,
-	}
-
-	switch {
-	case u.scheme == "gs":
-		src.modelSourcePodAdditions = authForGCS(r.SecretNames.GCP)
-	case u.scheme == "oss":
-		src.modelSourcePodAdditions = authForOSS(r.SecretNames.Alibaba)
-	case u.scheme == "s3":
-		src.modelSourcePodAdditions = authForS3(r.SecretNames.AWS)
-	case u.scheme == "hf":
-		src.modelSourcePodAdditions = authForHuggingfaceHub(r.SecretNames.Huggingface)
-	case u.scheme == "pvc":
-		src.modelSourcePodAdditions = pvcPodAdditions(u)
-	default:
-		src.modelSourcePodAdditions = &modelSourcePodAdditions{}
-	}
-	return src, nil
+	return modelSource{
+		url:                  u,
+		modelSourcePodAdditions: registry.Get(u.scheme).PodAdditions(u),
+	}, nil
 }
 
 type modelSourcePodAdditions struct {

--- a/internal/modelcontroller/model_source.go
+++ b/internal/modelcontroller/model_source.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	v1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/kubeai-project/kubeai/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 )
@@ -27,15 +28,15 @@ func (r *ModelReconciler) parseModelSource(urlStr string) (modelSource, error) {
 
 	switch {
 	case u.scheme == "gs":
-		src.modelSourcePodAdditions = r.authForGCS()
+		src.modelSourcePodAdditions = authForGCS(r.SecretNames.GCP)
 	case u.scheme == "oss":
-		src.modelSourcePodAdditions = r.authForOSS()
+		src.modelSourcePodAdditions = authForOSS(r.SecretNames.Alibaba)
 	case u.scheme == "s3":
-		src.modelSourcePodAdditions = r.authForS3()
+		src.modelSourcePodAdditions = authForS3(r.SecretNames.AWS)
 	case u.scheme == "hf":
-		src.modelSourcePodAdditions = r.authForHuggingfaceHub()
+		src.modelSourcePodAdditions = authForHuggingfaceHub(r.SecretNames.Huggingface)
 	case u.scheme == "pvc":
-		src.modelSourcePodAdditions = r.pvcPodAdditions(u)
+		src.modelSourcePodAdditions = pvcPodAdditions(u)
 	default:
 		src.modelSourcePodAdditions = &modelSourcePodAdditions{}
 	}
@@ -63,23 +64,23 @@ func (c *modelSourcePodAdditions) applyToPodSpec(spec *corev1.PodSpec, container
 	spec.Containers[containerIndex].VolumeMounts = append(spec.Containers[containerIndex].VolumeMounts, c.volumeMounts...)
 }
 
-func (r *ModelReconciler) modelAuthCredentialsForAllSources() *modelSourcePodAdditions {
+func modelAuthCredentialsForAllSources(secretNames config.SecretNames) *modelSourcePodAdditions {
 	c := &modelSourcePodAdditions{}
-	c.append(r.authForHuggingfaceHub())
-	c.append(r.authForGCS())
-	c.append(r.authForOSS())
-	c.append(r.authForS3())
+	c.append(authForHuggingfaceHub(secretNames.Huggingface))
+	c.append(authForGCS(secretNames.GCP))
+	c.append(authForOSS(secretNames.Alibaba))
+	c.append(authForS3(secretNames.AWS))
 	return c
 }
 
-func (r *ModelReconciler) modelEnvFrom(m *v1.Model) *modelSourcePodAdditions {
+func modelEnvFrom(m *v1.Model) *modelSourcePodAdditions {
 	if m.Spec.EnvFrom == nil {
 		return &modelSourcePodAdditions{}
 	}
 	return &modelSourcePodAdditions{envFrom: m.Spec.EnvFrom}
 }
 
-func (r *ModelReconciler) authForS3() *modelSourcePodAdditions {
+func authForS3(secretName string) *modelSourcePodAdditions {
 	return &modelSourcePodAdditions{
 		env: []corev1.EnvVar{
 			{
@@ -87,7 +88,7 @@ func (r *ModelReconciler) authForS3() *modelSourcePodAdditions {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: r.SecretNames.AWS,
+							Name: secretName,
 						},
 						Key:      "accessKeyID",
 						Optional: ptr.To(true),
@@ -99,7 +100,7 @@ func (r *ModelReconciler) authForS3() *modelSourcePodAdditions {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: r.SecretNames.AWS,
+							Name: secretName,
 						},
 						Key:      "secretAccessKey",
 						Optional: ptr.To(true),
@@ -110,7 +111,7 @@ func (r *ModelReconciler) authForS3() *modelSourcePodAdditions {
 	}
 }
 
-func (r *ModelReconciler) authForHuggingfaceHub() *modelSourcePodAdditions {
+func authForHuggingfaceHub(secretName string) *modelSourcePodAdditions {
 	return &modelSourcePodAdditions{
 		env: []corev1.EnvVar{
 			{
@@ -118,7 +119,7 @@ func (r *ModelReconciler) authForHuggingfaceHub() *modelSourcePodAdditions {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: r.SecretNames.Huggingface,
+							Name: secretName,
 						},
 						Key:      "token",
 						Optional: ptr.To(true),
@@ -129,7 +130,7 @@ func (r *ModelReconciler) authForHuggingfaceHub() *modelSourcePodAdditions {
 	}
 }
 
-func (r *ModelReconciler) authForGCS() *modelSourcePodAdditions {
+func authForGCS(secretName string) *modelSourcePodAdditions {
 	const (
 		credentialsDir      = "/secrets/gcp-credentials"
 		credentialsFilename = "credentials.json"
@@ -148,7 +149,7 @@ func (r *ModelReconciler) authForGCS() *modelSourcePodAdditions {
 				Name: volumeName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: r.SecretNames.GCP,
+						SecretName: secretName,
 						Items: []corev1.KeyToPath{
 							{
 								Key:  "jsonKeyfile",
@@ -169,7 +170,7 @@ func (r *ModelReconciler) authForGCS() *modelSourcePodAdditions {
 	}
 }
 
-func (r *ModelReconciler) authForOSS() *modelSourcePodAdditions {
+func authForOSS(secretName string) *modelSourcePodAdditions {
 	return &modelSourcePodAdditions{
 		env: []corev1.EnvVar{
 			{
@@ -177,7 +178,7 @@ func (r *ModelReconciler) authForOSS() *modelSourcePodAdditions {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: r.SecretNames.Alibaba,
+							Name: secretName,
 						},
 						Key:      "accessKeyID",
 						Optional: ptr.To(true),
@@ -189,7 +190,7 @@ func (r *ModelReconciler) authForOSS() *modelSourcePodAdditions {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: r.SecretNames.Alibaba,
+							Name: secretName,
 						},
 						Key:      "accessKeySecret",
 						Optional: ptr.To(true),
@@ -200,7 +201,7 @@ func (r *ModelReconciler) authForOSS() *modelSourcePodAdditions {
 	}
 }
 
-func (r *ModelReconciler) pvcPodAdditions(url modelURL) *modelSourcePodAdditions {
+func pvcPodAdditions(url modelURL) *modelSourcePodAdditions {
 	volumeName := "model"
 	// Kubernetes does not support an subPath with a leading slash. SubPath needs to be
 	// a relative path or empty string to mount the entire volume.

--- a/internal/modelcontroller/pod_plan.go
+++ b/internal/modelcontroller/pod_plan.go
@@ -26,18 +26,11 @@ import (
 // - Recreates any out-of-date Pod that is not Ready immediately
 // - Waits for all Pods to be Ready before recreating any out-of-date Pods that are Ready
 func (r *ModelReconciler) calculatePodPlan(allPods *corev1.PodList, model *kubeaiv1.Model, modelConfig ModelConfig) (*podPlan, error) {
-	var podForModel *corev1.Pod
-
-	switch model.Spec.Engine {
-	case kubeaiv1.OLlamaEngine:
-		podForModel = r.oLlamaPodForModel(model, modelConfig)
-	case kubeaiv1.FasterWhisperEngine:
-		podForModel = r.fasterWhisperPodForModel(model, modelConfig)
-	case kubeaiv1.InfinityEngine:
-		podForModel = r.infinityPodForModel(model, modelConfig)
-	default:
-		podForModel = r.vLLMPodForModel(model, modelConfig)
+	engine, err := r.EngineRegistry.Get(model.Spec.Engine)
+	if err != nil {
+		return nil, err
 	}
+	podForModel := engine.PodForModel(model, modelConfig)
 
 	if err := applyJSONPatchToPod(r.ModelServerPods.JSONPatches, podForModel); err != nil {
 		return nil, err

--- a/internal/modelcontroller/pod_plan_test.go
+++ b/internal/modelcontroller/pod_plan_test.go
@@ -45,7 +45,7 @@ func Test_calculatePodPlan(t *testing.T) {
 		},
 	}
 
-	src, err := r.parseModelSource(model.Spec.URL)
+	src, err := parseModelSource(model.Spec.URL, NewSourceRegistry(config.SecretNames{}))
 	require.NoError(t, err)
 	modelConfig := ModelConfig{
 		ResourceProfile: config.ResourceProfile{

--- a/internal/modelcontroller/pod_plan_test.go
+++ b/internal/modelcontroller/pod_plan_test.go
@@ -31,6 +31,7 @@ func Test_calculatePodPlan(t *testing.T) {
 			Surge: 1,
 		},
 	}
+	r.EngineRegistry = NewEngineRegistry(EngineConfig{})
 
 	model := &v1.Model{
 		ObjectMeta: metav1.ObjectMeta{
@@ -59,7 +60,7 @@ func Test_calculatePodPlan(t *testing.T) {
 		Source: src,
 	}
 
-	expectedHash := k8sutils.PodHash(r.vLLMPodForModel(model, modelConfig).Spec)
+	expectedHash := k8sutils.PodHash((&VLLMEngine{}).PodForModel(model, modelConfig).Spec)
 
 	type readiness bool
 	const ready = readiness(true)


### PR DESCRIPTION
Depends on #678.

Applies the same hexagonal pattern to `parseModelSource`. Replaces the switch with a `ModelSourceProvider` port and per-scheme adapter structs, wired by `NewSourceRegistry`.