### PR TITLE
proxy: preserve original request body when no rewrite is needed

### DIFF
--- a/internal/apiutils/request.go
+++ b/internal/apiutils/request.go
@@ -180,7 +180,12 @@ func (r *Request) readJSONBody(body io.Reader, path string) error {
 		return fmt.Errorf("unknown path: %q", path)
 	}
 
-	if err := json.UnmarshalRead(body, r.modelRequest); err != nil {
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		return fmt.Errorf("reading: %w", err)
+	}
+
+	if err := json.Unmarshal(raw, r.modelRequest); err != nil {
 		return fmt.Errorf("decoding: %w", err)
 	}
 
@@ -194,13 +199,19 @@ func (r *Request) readJSONBody(body io.Reader, path string) error {
 	if r.Adapter != "" {
 		// vLLM expects the adapter to be in the model field.
 		r.modelRequest.SetModel(r.Adapter)
-	}
 
-	rewritten, err := json.Marshal(r.modelRequest)
-	if err != nil {
-		return fmt.Errorf("remarshalling: %w", err)
+		rewritten, err := json.Marshal(r.modelRequest)
+		if err != nil {
+			return fmt.Errorf("remarshalling: %w", err)
+		}
+		r.Body = rewritten
+	} else {
+		// Preserve the original body bytes. Re-serializing shuffles JSON map
+		// key order (e.g. tool JSON schemas typed as `any`), which changes the
+		// rendered prompt on every request and breaks prompt caching in
+		// downstream inference servers.
+		r.Body = raw
 	}
-	r.Body = rewritten
 	r.ContentLength = int64(len(r.Body))
 
 	return nil

--- a/internal/apiutils/request_test.go
+++ b/internal/apiutils/request_test.go
@@ -65,6 +65,13 @@ func TestParseRequest(t *testing.T) {
 			path:     "/v1/rerank",
 			expModel: "test-model",
 		},
+		{
+			name:      "chat completion with tool schema",
+			body:      `{"model": "test-model", "messages": [{"role": "user", "content": "test"}], "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get current weather", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "City name"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location"]}}}, {"type": "function", "function": {"name": "get_time", "description": "Get current time", "parameters": {"type": "object", "properties": {"timezone": {"type": "string", "description": "IANA tz"}, "format": {"type": "string", "enum": ["12h", "24h"]}}, "required": ["timezone"]}}}]}`,
+			path:      "/v1/chat/completions",
+			expModel:  "test-model",
+			expPrefix: "test",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -78,6 +85,11 @@ func TestParseRequest(t *testing.T) {
 			require.Equal(t, c.expModel, req.Model, "model")
 			require.Equal(t, c.expAdapter, req.Adapter, "adapter")
 			require.Equal(t, c.expPrefix, req.Prefix, "prefix")
+
+			if c.expAdapter == "" {
+				require.Equal(t, c.body, string(req.Body),
+					"no-adapter path must forward the client body byte-for-byte")
+			}
 		})
 	}
 


### PR DESCRIPTION
Fixes #690.

The proxy currently re-marshals every request body even when it doesn't change anything. Untyped fields like tool parameter schemas round-trip through maps, and jsonv2 writes those in non-deterministic key order - so byte-identical client requests reach the backend with their tool schemas shuffled differently every time. Any prompt/prefix cache in the backend (vLLM, llama.cpp, Ollama) stops matching after the first tool definition.

This keeps the original body bytes unless the model field actually has to be rewritten for an adapter.

We run this in production: an identical 22k-token agentic request went from a full re-prefill (90+ s on our hardware) to a ~1 s cache hit. Existing apiutils tests pass unchanged.