### PR TITLE
Controller watch scope

### DIFF
--- a/charts/kubeai/templates/configmap.yaml
+++ b/charts/kubeai/templates/configmap.yaml
@@ -13,6 +13,10 @@ data:
       huggingface: {{ include "kubeai.huggingfaceSecretName" . }}
     proxy:
       mode: {{ .Values.proxy.mode }}
+    {{- with .Values.watchNamespaces }}
+    watchNamespaces:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     resourceProfiles:
       {{- .Values.resourceProfiles | toYaml | nindent 6 }}
     cacheProfiles:

--- a/charts/kubeai/templates/deployment.yaml
+++ b/charts/kubeai/templates/deployment.yaml
@@ -44,7 +44,8 @@ spec:
           env:
           - name: CONFIG_PATH
             value: "/app/config/system.yaml"
-          # Configure kubeai to only manage objects in its own namespace.
+          # POD_NAMESPACE is the operator's own namespace. It is always watched
+          # (see .Values.watchNamespaces to expand the watch scope).
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/charts/kubeai/templates/role.yaml
+++ b/charts/kubeai/templates/role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ include "kubeai.fullname" . }}
   labels:

--- a/charts/kubeai/templates/rolebinding.yaml
+++ b/charts/kubeai/templates/rolebinding.yaml
@@ -1,13 +1,49 @@
+{{- $watchAll := false -}}
+{{- range .Values.watchNamespaces -}}
+{{- if eq . "*" -}}
+{{- $watchAll = true -}}
+{{- end -}}
+{{- end -}}
+{{- if $watchAll }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "kubeai.fullname" . }}
   labels:
     {{- include "kubeai.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ include "kubeai.fullname" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "kubeai.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- else -}}
+{{- /* Bind to the release namespace first so that leader election, autoscaler state, and
+       Models in the operator's own namespace continue to work. */ -}}
+{{- $ns := list .Release.Namespace -}}
+{{- range .Values.watchNamespaces -}}
+{{- if ne . $.Release.Namespace -}}
+{{- $ns = append $ns . -}}
+{{- end -}}
+{{- end -}}
+{{- range $ns }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kubeai.fullname" $ }}
+  namespace: {{ . }}
+  labels:
+    {{- include "kubeai.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kubeai.fullname" $ }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubeai.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -99,6 +99,15 @@ proxy:
   # Valid values: internal, external
   mode: "internal"
 
+# watchNamespaces restricts the set of namespaces that the controller reconciles
+# Model resources in.
+#   - [] (default): watch only the release namespace. Uses a namespace-scoped RoleBinding.
+#   - ["*"]:        watch all namespaces. Uses a ClusterRoleBinding.
+#   - ["a", "b"]:   watch the listed namespaces. Emits one RoleBinding per namespace
+#                   plus the release namespace (which is always watched so that
+#                   leader election and autoscaler state remain functional).
+watchNamespaces: []
+
 metrics:
   prometheusOperator:
     vLLMPodMonitor:

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -46,6 +46,23 @@ type System struct {
 
 	// FixedSelfMetricAddrs is a list of fixed addresses to be used when scraping metrics for autoscaling. Useful for development purposes.
 	FixedSelfMetricAddrs []string `json:"fixedSelfMetricAddrs,omitempty"`
+
+	// WatchNamespaces restricts the set of namespaces that the controller watches for Model resources.
+	//   - nil or empty: watch only the operator's own namespace (POD_NAMESPACE). Backward compatible.
+	//   - ["*"]:        watch all namespaces (cluster-wide).
+	//   - list:         watch the given namespaces. The operator's own namespace is always included so
+	//                   that the leader-election lease and autoscaler state ConfigMap remain observable.
+	WatchNamespaces []string `json:"watchNamespaces,omitempty"`
+}
+
+// ClusterWide reports whether the controller should watch all namespaces.
+func (s *System) ClusterWide() bool {
+	for _, ns := range s.WatchNamespaces {
+		if ns == "*" {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *System) DefaultAndValidate() error {

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -138,6 +139,24 @@ func Run(ctx context.Context, k8sCfg *rest.Config, cfg config.System) error {
 		SecureServing: false,
 	}
 
+	cacheOpts := cache.Options{
+		Scheme: Scheme, //mgr.GetScheme(),
+	}
+	if !cfg.ClusterWide() {
+		// Restrict operations to the requested set of namespaces.
+		// The operator's own namespace is always included so that the leader-election
+		// lease and autoscaler state ConfigMap remain observable.
+		// (this should also be enforced by Namespaced RBAC rules)
+		nsSet := map[string]cache.Config{namespace: {}}
+		for _, ns := range cfg.WatchNamespaces {
+			nsSet[ns] = cache.Config{}
+		}
+		cacheOpts.DefaultNamespaces = nsSet
+		Log.Info("watching namespaces", "namespaces", nsSetKeys(nsSet))
+	} else {
+		Log.Info("watching all namespaces (cluster-wide)")
+	}
+
 	SkipNameValidation := true
 	mgr, err := ctrl.NewManager(k8sCfg, ctrl.Options{
 		Scheme:  Scheme,
@@ -152,14 +171,7 @@ func Run(ctx context.Context, k8sCfg *rest.Config, cfg config.System) error {
 		RenewDeadline:           ptr.To(cfg.LeaderElection.RenewDeadline.Duration),
 		RetryPeriod:             ptr.To(cfg.LeaderElection.RetryPeriod.Duration),
 		Controller:              controllerconfig.Controller{SkipNameValidation: &SkipNameValidation},
-		Cache: cache.Options{
-			Scheme: Scheme, //mgr.GetScheme(),
-			DefaultNamespaces: map[string]cache.Config{
-				// Restrict operations to this Namespace.
-				// (this should also be enforced by Namespaced RBAC rules)
-				namespace: {},
-			},
-		},
+		Cache:                   cacheOpts,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
@@ -418,6 +430,15 @@ func Run(ctx context.Context, k8sCfg *rest.Config, cfg config.System) error {
 	Log.Info("run goroutines finished")
 
 	return nil
+}
+
+func nsSetKeys(m map[string]cache.Config) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // parsePortFromAddr takes a string like ":8080" and returns 8080.

--- a/internal/modelclient/client.go
+++ b/internal/modelclient/client.go
@@ -3,17 +3,22 @@ package modelclient
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var logger = ctrl.Log.WithName("modelclient")
+
 type ModelClient struct {
-	client                   client.Client
+	client client.Client
+	// namespace is the operator's own namespace. It is used as a
+	// disambiguation preference when multiple Models share a name across watched
+	// namespaces: a match in this namespace wins over matches elsewhere.
 	namespace                string
 	consecutiveScaleDownsMtx sync.RWMutex
 	consecutiveScaleDowns    map[string]int
@@ -23,15 +28,29 @@ func NewModelClient(client client.Client, namespace string) *ModelClient {
 	return &ModelClient{client: client, namespace: namespace, consecutiveScaleDowns: map[string]int{}}
 }
 
-// LookupModel checks if a model exists and matches the given label selectors.
+// LookupModel finds a Model by name across all watched namespaces and checks
+// that it matches the given label selectors.
+//
+// When multiple Models share the same name across namespaces (this is possible
+// because Model is namespace-scoped), a match in the operator's own namespace
+// wins; otherwise the namespace that sorts first alphabetically is chosen and a
+// warning is logged.
 func (c *ModelClient) LookupModel(ctx context.Context, model, adapter string, labelSelectors []string) (*kubeaiv1.Model, error) {
-	m := &kubeaiv1.Model{}
-	if err := c.client.Get(ctx, types.NamespacedName{Name: model, Namespace: c.namespace}, m); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
+	list := &kubeaiv1.ModelList{}
+	if err := c.client.List(ctx, list); err != nil {
+		return nil, fmt.Errorf("list models: %w", err)
 	}
+
+	var matches []kubeaiv1.Model
+	for i := range list.Items {
+		if list.Items[i].Name == model {
+			matches = append(matches, list.Items[i])
+		}
+	}
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	m := pickModel(matches, c.namespace)
 
 	modelLabels := m.GetLabels()
 	if modelLabels == nil {
@@ -65,9 +84,39 @@ func (c *ModelClient) LookupModel(ctx context.Context, model, adapter string, la
 
 func (s *ModelClient) ListAllModels(ctx context.Context) ([]kubeaiv1.Model, error) {
 	models := &kubeaiv1.ModelList{}
-	if err := s.client.List(ctx, models, client.InNamespace(s.namespace)); err != nil {
+	if err := s.client.List(ctx, models); err != nil {
 		return nil, fmt.Errorf("list models: %w", err)
 	}
 
 	return models.Items, nil
+}
+
+// pickModel selects a single Model from a set of same-named matches. A match in
+// preferredNS wins; otherwise the alphabetically-first namespace is picked. If
+// more than one match exists, a warning is emitted so operators can detect the
+// collision.
+func pickModel(matches []kubeaiv1.Model, preferredNS string) *kubeaiv1.Model {
+	if len(matches) == 1 {
+		return &matches[0]
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].Namespace < matches[j].Namespace
+	})
+	chosen := &matches[0]
+	for i := range matches {
+		if matches[i].Namespace == preferredNS {
+			chosen = &matches[i]
+			break
+		}
+	}
+	namespaces := make([]string, len(matches))
+	for i, m := range matches {
+		namespaces[i] = m.Namespace
+	}
+	logger.Info("model name collision across namespaces; picking one deterministically",
+		"model", chosen.Name,
+		"chosen_namespace", chosen.Namespace,
+		"all_namespaces", namespaces,
+	)
+	return chosen
 }

--- a/internal/modelclient/client_test.go
+++ b/internal/modelclient/client_test.go
@@ -1,0 +1,98 @@
+package modelclient
+
+import (
+	"context"
+	"testing"
+
+	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const operatorNS = "kubeai-system"
+
+func newTestClient(t *testing.T, models ...*kubeaiv1.Model) *ModelClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, kubeaiv1.AddToScheme(scheme))
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, m := range models {
+		builder = builder.WithObjects(m)
+	}
+	return NewModelClient(builder.Build(), operatorNS)
+}
+
+func model(ns, name string) *kubeaiv1.Model {
+	return &kubeaiv1.Model{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec: kubeaiv1.ModelSpec{
+			URL:             "hf://x/y",
+			Engine:          "VLLM",
+			Features:        []kubeaiv1.ModelFeature{kubeaiv1.ModelFeatureTextGeneration},
+			ResourceProfile: "cpu:1",
+		},
+	}
+}
+
+func TestLookupModel_NotFound(t *testing.T) {
+	c := newTestClient(t)
+	m, err := c.LookupModel(context.Background(), "missing", "", nil)
+	require.NoError(t, err)
+	require.Nil(t, m)
+}
+
+func TestLookupModel_SingleNamespace(t *testing.T) {
+	c := newTestClient(t, model(operatorNS, "llama"))
+	m, err := c.LookupModel(context.Background(), "llama", "", nil)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	require.Equal(t, operatorNS, m.Namespace)
+}
+
+func TestLookupModel_CrossNamespace(t *testing.T) {
+	c := newTestClient(t, model("team-a", "llama"))
+	m, err := c.LookupModel(context.Background(), "llama", "", nil)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	require.Equal(t, "team-a", m.Namespace)
+}
+
+func TestLookupModel_CollisionPrefersOperatorNamespace(t *testing.T) {
+	c := newTestClient(t,
+		model("team-a", "llama"),
+		model(operatorNS, "llama"),
+		model("team-b", "llama"),
+	)
+	m, err := c.LookupModel(context.Background(), "llama", "", nil)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	require.Equal(t, operatorNS, m.Namespace, "match in operator namespace should win")
+}
+
+func TestLookupModel_CollisionAlphabeticalFallback(t *testing.T) {
+	// No match in operator namespace; alphabetically-first namespace wins.
+	c := newTestClient(t,
+		model("team-c", "llama"),
+		model("team-a", "llama"),
+		model("team-b", "llama"),
+	)
+	m, err := c.LookupModel(context.Background(), "llama", "", nil)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	require.Equal(t, "team-a", m.Namespace)
+}
+
+func TestListAllModels_AcrossNamespaces(t *testing.T) {
+	c := newTestClient(t,
+		model(operatorNS, "a"),
+		model("team-a", "b"),
+		model("team-b", "c"),
+	)
+	models, err := c.ListAllModels(context.Background())
+	require.NoError(t, err)
+	require.Len(t, models, 3)
+}

--- a/internal/modelclient/scale.go
+++ b/internal/modelclient/scale.go
@@ -7,14 +7,16 @@ import (
 
 	kubeaiv1 "github.com/kubeai-project/kubeai/api/k8s/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (c *ModelClient) ScaleAtLeastOneReplica(ctx context.Context, model string) error {
-	obj := &kubeaiv1.Model{}
-	if err := c.client.Get(ctx, types.NamespacedName{Namespace: c.namespace, Name: model}, obj); err != nil {
-		return fmt.Errorf("get scale: %w", err)
+	obj, err := c.LookupModel(ctx, model, "", nil)
+	if err != nil {
+		return fmt.Errorf("lookup model: %w", err)
+	}
+	if obj == nil {
+		return fmt.Errorf("model %q not found", model)
 	}
 
 	if obj.Spec.AutoscalingDisabled {


### PR DESCRIPTION
The controller was hard-coded to watch its own namespace, so Models created elsewhere were never reconciled.

Adds a `watchNamespaces` config option:
- unset (default): watch the release namespace — backward compatible
- `["*"]`: watch all namespaces
- explicit list: watch the listed namespaces plus the release namespace

The Helm chart converts the existing `Role` to a `ClusterRole` and picks the binding based on the value: `RoleBinding` (default), per-namespace `RoleBinding`s (list), or `ClusterRoleBinding` (`*`).

Model lookup in the proxy/autoscaler lists across all watched namespaces. On a same-name collision, a match in the operator's own namespace wins; otherwise the alphabetically-first namespace is picked and a warning is logged.

Fixes #685