### PR TITLE
ci: improve image build workflow

### DIFF
--- a/.github/workflows/build-push-kubeai.yml
+++ b/.github/workflows/build-push-kubeai.yml
@@ -1,4 +1,5 @@
 name: Build and Push kubeai Docker image
+
 on:
   push:
     branches:
@@ -7,51 +8,28 @@ on:
       - "v*.*.*"
     paths-ignore:
       - '**/README.md'
-  pull_request:
-
-# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: kubeai-project/kubeai
 
 jobs:
-  kubeai:
-    runs-on: ubuntu-latest
-    # Timeout to address Github actions stuck scenarios.
-    timeout-minutes: 60
-    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+  build:
+    uses: docker/github-builder/.github/workflows/build.yml@v1
     permissions:
       contents: read
+      id-token: write
       packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Log in to the Container registry
-        if: github.event_name == 'push'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
+    with:
+      output: image
+      push: true
+      platforms: linux/amd64,linux/arm64
+      context: .
+      file: Dockerfile
+      cache: true
+      cache-scope: kubeai
+      cache-mode: max
+      meta-images: ghcr.io/${{ github.repository_owner }}/kubeai
+      set-meta-labels: true
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-push-model-loader.yml
+++ b/.github/workflows/build-push-model-loader.yml
@@ -1,4 +1,5 @@
 name: Build and Push kubeai-model-loader Docker image
+
 on:
   push:
     branches:
@@ -7,55 +8,28 @@ on:
       - "v*.*.*"
     paths-ignore:
       - '**/README.md'
-  pull_request:
-
-# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: kubeai-project/kubeai-model-loader
 
 jobs:
-  kubeai-model-loader:
-    runs-on: ubuntu-latest
-    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+  build:
+    uses: docker/github-builder/.github/workflows/build.yml@v1
     permissions:
-      contents: read
+      contents: read # to fetch the repository content
+      id-token: write # for signing attestation(s) with GitHub OIDC Token
       packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Log in to the Container registry
-        if: github.event_name == 'push'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
+    with:
+      output: image
+      push: true
+      platforms: linux/amd64,linux/arm64
+      context: ./components/model-loader
+      file: Dockerfile
+      cache: true
+      cache-scope: kubeai-model-loader
+      cache-mode: max
+      meta-images: ghcr.io/${{ github.repository_owner }}/kubeai-model-loader
+      set-meta-labels: true
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      # - name: Login to docker.io
-      #   if: github.event_name == 'push'
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ vars.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            # ${{ env.IMAGE_NAME }}
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./components/model-loader
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Improve image build workflow using github shared arm runner. This will improve the speed of the build workflows, decresing the execution time from ~30 to ~4 minute.