### PR TITLE
ci: add missing checkout step in GitHub release workflow

### DIFF
--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -15,6 +15,8 @@ jobs:
     name: Release pushed tag
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
+      
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add missing checkout step in GitHub release workflow, with this the release work flow should work as expected.